### PR TITLE
Feature/clubs administration page

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@mui/x-date-pickers": "^7.12.0",
     "@nextui-org/react": "^2.4.1",
     "@react-stately/data": "^3.11.4",
+    "@tanstack/react-query": "^5.53.1",
     "@types/papaparse": "^5.3.14",
     "clsx": "^2.0.0",
     "dayjs": "^1.11.12",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@types/papaparse": "^5.3.14",
     "clsx": "^2.0.0",
     "dayjs": "^1.11.12",
+    "dotenv": "^16.4.5",
     "framer-motion": "^11.2.4",
     "lucide-react": "^0.376.0",
     "mongodb": "^6.8.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,7 +37,7 @@ importers:
         version: 3.11.6(react@18.3.1)
       '@tanstack/react-query':
         specifier: ^5.53.1
-        version: 5.53.1(react@18.3.1)
+        version: 5.55.4(react@18.3.1)
       '@types/papaparse':
         specifier: ^5.3.14
         version: 5.3.14
@@ -2655,11 +2655,11 @@ packages:
     peerDependencies:
       tailwindcss: '>=3.0.0 || >= 3.0.0-alpha.1'
 
-  '@tanstack/query-core@5.53.1':
-    resolution: {integrity: sha512-mvLG7s4Zy3Yvc2LsKm8BVafbmPrsReKgqwhmp4XKVmRW9us3KbWRqu3qBBfhVavcUUEHfNK7PvpTchvQpVdFpw==}
+  '@tanstack/query-core@5.55.4':
+    resolution: {integrity: sha512-uoRqNnRfzOH4OMIoxj8E2+Us89UIGXfau981qYJWsNMkFS1GXR4UIyzUTVGq4N7SDLHgFPpo6IOazqUV5gkMZA==}
 
-  '@tanstack/react-query@5.53.1':
-    resolution: {integrity: sha512-35HU4836Ey1/W74BxmS8p9KHXcDRGPdkw6w3VX0Tc5S9v5acFl80oi/yc6nsmoLhu68wQkWMyX0h7y7cOtY5OA==}
+  '@tanstack/react-query@5.55.4':
+    resolution: {integrity: sha512-e3uX5XkLD9oTV66/VsVpkYz3Ds/ps/Yk+V5d89xthAbtNIKKBEm4FdNb9yISFzGEGezUzVO68qmfmiSrtScvsg==}
     peerDependencies:
       react: ^18 || ^19
 
@@ -9732,18 +9732,11 @@ snapshots:
       mini-svg-data-uri: 1.4.4
       tailwindcss: 3.4.10(ts-node@10.9.2(@types/node@22.5.0)(typescript@4.9.5))
 
-  '@tanstack/query-core@5.53.1': {}
+  '@tanstack/query-core@5.55.4': {}
 
-  '@tanstack/react-query@5.53.1(react@18.3.1)':
+  '@tanstack/react-query@5.55.4(react@18.3.1)':
     dependencies:
-      '@tanstack/query-core': 5.53.1
-      react: 18.3.1
-
-  '@tanstack/query-core@5.53.1': {}
-
-  '@tanstack/react-query@5.53.1(react@18.3.1)':
-    dependencies:
-      '@tanstack/query-core': 5.53.1
+      '@tanstack/query-core': 5.55.4
       react: 18.3.1
 
   '@testing-library/dom@8.20.1':
@@ -13201,6 +13194,7 @@ snapshots:
       '@mui/x-date-pickers': 7.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@18.3.1))(@types/react@18.3.4)(react@18.3.1))(@mui/material@5.16.7(@emotion/react@11.13.3(@types/react@18.3.4)(react@18.3.1))(@emotion/styled@11.13.0(@emotion/react@11.13.3(@types/react@18.3.4)(react@18.3.1))(@types/react@18.3.4)(react@18.3.1))(@types/react@18.3.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.4)(dayjs@1.11.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@nextui-org/react': 2.4.6(@types/react@18.3.4)(framer-motion@11.3.29(@emotion/is-prop-valid@1.3.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(tailwindcss@3.4.10(ts-node@10.9.2(@types/node@22.5.0)(typescript@4.9.5)))
       '@react-stately/data': 3.11.6(react@18.3.1)
+      '@tanstack/react-query': 5.55.4(react@18.3.1)
       '@types/papaparse': 5.3.14
       clsx: 2.1.1
       dayjs: 1.11.13

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       '@react-stately/data':
         specifier: ^3.11.4
         version: 3.11.6(react@18.3.1)
+      '@tanstack/react-query':
+        specifier: ^5.53.1
+        version: 5.53.1(react@18.3.1)
       '@types/papaparse':
         specifier: ^5.3.14
         version: 5.3.14
@@ -2651,6 +2654,14 @@ packages:
     resolution: {integrity: sha512-QE7X69iQI+ZXwldE+rzasvbJiyV/ju1FGHH0Qn2W3FKbuYtqp8LKcy6iSw79fVUT5/Vvf+0XgLCeYVG+UV6hOw==}
     peerDependencies:
       tailwindcss: '>=3.0.0 || >= 3.0.0-alpha.1'
+
+  '@tanstack/query-core@5.53.1':
+    resolution: {integrity: sha512-mvLG7s4Zy3Yvc2LsKm8BVafbmPrsReKgqwhmp4XKVmRW9us3KbWRqu3qBBfhVavcUUEHfNK7PvpTchvQpVdFpw==}
+
+  '@tanstack/react-query@5.53.1':
+    resolution: {integrity: sha512-35HU4836Ey1/W74BxmS8p9KHXcDRGPdkw6w3VX0Tc5S9v5acFl80oi/yc6nsmoLhu68wQkWMyX0h7y7cOtY5OA==}
+    peerDependencies:
+      react: ^18 || ^19
 
   '@testing-library/dom@8.20.1':
     resolution: {integrity: sha512-/DiOQ5xBxgdYRC8LNk7U+RWat0S3qRLeIw3ZIkMQ9kkVlRmwD/Eg8k8CqIpD6GW7u20JIUOfMKbxtiLutpjQ4g==}
@@ -9721,6 +9732,20 @@ snapshots:
       mini-svg-data-uri: 1.4.4
       tailwindcss: 3.4.10(ts-node@10.9.2(@types/node@22.5.0)(typescript@4.9.5))
 
+  '@tanstack/query-core@5.53.1': {}
+
+  '@tanstack/react-query@5.53.1(react@18.3.1)':
+    dependencies:
+      '@tanstack/query-core': 5.53.1
+      react: 18.3.1
+
+  '@tanstack/query-core@5.53.1': {}
+
+  '@tanstack/react-query@5.53.1(react@18.3.1)':
+    dependencies:
+      '@tanstack/query-core': 5.53.1
+      react: 18.3.1
+
   '@testing-library/dom@8.20.1':
     dependencies:
       '@babel/code-frame': 7.24.7
@@ -13179,6 +13204,7 @@ snapshots:
       '@types/papaparse': 5.3.14
       clsx: 2.1.1
       dayjs: 1.11.13
+      dotenv: 16.4.5
       framer-motion: 11.3.29(@emotion/is-prop-valid@1.3.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       lucide-react: 0.376.0(react@18.3.1)
       mongodb: 6.8.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       dayjs:
         specifier: ^1.11.12
         version: 1.11.13
+      dotenv:
+        specifier: ^16.4.5
+        version: 16.4.5
       framer-motion:
         specifier: ^11.2.4
         version: 11.3.29(@emotion/is-prop-valid@1.3.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -3493,6 +3496,10 @@ packages:
   dot-prop@5.3.0:
     resolution: {integrity: sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==}
     engines: {node: '>=8'}
+
+  dotenv@16.4.5:
+    resolution: {integrity: sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==}
+    engines: {node: '>=12'}
 
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
@@ -10667,6 +10674,8 @@ snapshots:
   dot-prop@5.3.0:
     dependencies:
       is-obj: 2.0.0
+
+  dotenv@16.4.5: {}
 
   eastasianwidth@0.2.0: {}
 

--- a/src/app/api/clubs/get-profile/route.ts
+++ b/src/app/api/clubs/get-profile/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 
-import { getProfileByClubId } from '@/lib/db/clubProfileDb';
+import { getProfileByClubIdService } from '@/lib/services/clubProfileServices';
 import { TApiResponse, TMessageResponse } from '@/lib/types';
 
 import { TClubProfile } from '@/types/clubProfile';
@@ -14,7 +14,7 @@ export async function GET(req: NextRequest) {
     });
   }
 
-  const clubProfile = await getProfileByClubId(clubId);
+  const clubProfile = await getProfileByClubIdService(clubId);
 
   if (!clubProfile) {
     return NextResponse.json<TMessageResponse>({

--- a/src/app/api/clubs/get-profile/route.ts
+++ b/src/app/api/clubs/get-profile/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import { getProfileByClubId } from '@/lib/db/clubProfileDb';
+import { TApiResponse, TMessageResponse } from '@/lib/types';
+
+import { TClubProfile } from '@/types/clubProfile';
+
+export async function GET(req: NextRequest) {
+  const clubId = req.headers.get('club-id');
+
+  if (!clubId) {
+    return NextResponse.json<TMessageResponse>({
+      message: 'Club ID is required in headers',
+    });
+  }
+
+  const clubProfile = await getProfileByClubId(clubId);
+
+  if (!clubProfile) {
+    return NextResponse.json<TMessageResponse>({
+      message: 'Club profile not found',
+    });
+  }
+
+  return NextResponse.json<TApiResponse<TClubProfile>>({
+    data: clubProfile,
+  });
+}

--- a/src/app/api/clubs/update-profile/route.ts
+++ b/src/app/api/clubs/update-profile/route.ts
@@ -5,18 +5,15 @@ import { TApiResponse, TMessageResponse } from '@/lib/types';
 
 import { TClubProfile } from '@/types/clubProfile';
 
-export async function POST(req: NextRequest) {
-  const clubId = req.headers.get('club-id');
-
-  if (!clubId) {
+export async function PATCH(req: NextRequest) {
+  const profileUpdates: Partial<TClubProfile> = await req.json();
+  if (!profileUpdates.clubId) {
     return NextResponse.json<TMessageResponse>({
-      message: 'Club ID is required in headers',
+      message: 'Club ID is required in request body',
     });
   }
-
-  const updatedProfile: TClubProfile = await req.json();
-
-  const result = await updateProfileByClubId(clubId, updatedProfile);
+  const clubId = profileUpdates.clubId;
+  const result = await updateProfileByClubId(clubId, profileUpdates);
 
   if (!result) {
     return NextResponse.json<TMessageResponse>({

--- a/src/app/api/clubs/update-profile/route.ts
+++ b/src/app/api/clubs/update-profile/route.ts
@@ -1,0 +1,30 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import { updateProfileByClubId } from '@/lib/db/clubProfileDb';
+import { TApiResponse, TMessageResponse } from '@/lib/types';
+
+import { TClubProfile } from '@/types/clubProfile';
+
+export async function POST(req: NextRequest) {
+  const clubId = req.headers.get('club-id');
+
+  if (!clubId) {
+    return NextResponse.json<TMessageResponse>({
+      message: 'Club ID is required in headers',
+    });
+  }
+
+  const updatedProfile: TClubProfile = await req.json();
+
+  const result = await updateProfileByClubId(clubId, updatedProfile);
+
+  if (!result) {
+    return NextResponse.json<TMessageResponse>({
+      message: 'Failed to update profile',
+    });
+  }
+
+  return NextResponse.json<TApiResponse<TClubProfile>>({
+    data: result,
+  });
+}

--- a/src/app/api/clubs/update-profile/route.ts
+++ b/src/app/api/clubs/update-profile/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server';
 
-import { updateProfileByClubId } from '@/lib/db/clubProfileDb';
+import { updateProfileByClubIdService } from '@/lib/services/clubProfileServices';
 import { TApiResponse, TMessageResponse } from '@/lib/types';
 
 import { TClubProfile } from '@/types/clubProfile';
@@ -13,7 +13,7 @@ export async function PATCH(req: NextRequest) {
     });
   }
   const clubId = profileUpdates.clubId;
-  const result = await updateProfileByClubId(clubId, profileUpdates);
+  const result = await updateProfileByClubIdService(clubId, profileUpdates);
 
   if (!result) {
     return NextResponse.json<TMessageResponse>({

--- a/src/app/clubs-portal/admin/layout.tsx
+++ b/src/app/clubs-portal/admin/layout.tsx
@@ -1,0 +1,17 @@
+import { Metadata } from 'next';
+import * as React from 'react';
+
+import '@/styles/colors.css';
+
+export const metadata: Metadata = {
+  title: 'Clubs Admin Portal',
+  description: 'A web portal where the club administrator can manage clubs.',
+};
+
+export default function AdminLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <>{children}</>;
+}

--- a/src/app/clubs-portal/admin/page.tsx
+++ b/src/app/clubs-portal/admin/page.tsx
@@ -1,0 +1,33 @@
+import { ManageClubsSection } from '@/components/clubs-portal/admin/ManageClubs';
+import UHSForms from '@/components/clubs-portal/admin/UHSForms';
+import { ClubsSidebar } from '@/components/layout/clubs-user-dashboard/ClubsSidebar';
+
+import AdminSidebarItems from '@/constant/clubs-dashboard/AdminSidebarItems';
+
+const PendingUHSForms = () => {
+  return (
+    <div>
+      <h3>Pending UHS Forms</h3>
+    </div>
+  );
+};
+
+export default function AdminPortal() {
+  return (
+    <div className='AdminPortal'>
+      <div className='flex h-screen w-screen'>
+        <ClubsSidebar items={AdminSidebarItems} clubName='Admin' />
+        <div className='w-full px-12 pt-12'>
+          <h1>Admin Dashboard</h1>
+          <div className='w-full px-0 pt-12'>
+            <PendingUHSForms />
+          </div>
+          <div className='w-full h-1/2 px-0 pt-12'>
+            <UHSForms />
+          </div>
+          <ManageClubsSection />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/clubs-portal/administration/layout.tsx
+++ b/src/app/clubs-portal/administration/layout.tsx
@@ -1,0 +1,18 @@
+import { Metadata } from 'next';
+import * as React from 'react';
+
+import '@/styles/colors.css';
+
+export const metadata: Metadata = {
+  title: 'Club Administration',
+  description:
+    'A page where clubs administrators can manage their club profile',
+};
+
+export default function ClubAdministrationLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <>{children}</>;
+}

--- a/src/app/clubs-portal/administration/page.tsx
+++ b/src/app/clubs-portal/administration/page.tsx
@@ -1,12 +1,18 @@
+'use client';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import * as React from 'react';
 
 import ClubAdministrationContent from '@/components/clubs-portal/administration/ClubAdministrationContent';
 import ClubUserDashboardLayout from '@/components/layout/clubs-user-dashboard/ClubUserDashboardLayout';
 
+const queryClient = new QueryClient();
 export default function ClubsPortal() {
   return (
     <ClubUserDashboardLayout pageName='Club Administration'>
-      <ClubAdministrationContent />
+      <QueryClientProvider client={queryClient}>
+        <ClubAdministrationContent />
+      </QueryClientProvider>
     </ClubUserDashboardLayout>
   );
 }

--- a/src/app/clubs-portal/administration/page.tsx
+++ b/src/app/clubs-portal/administration/page.tsx
@@ -1,0 +1,12 @@
+import * as React from 'react';
+
+import ClubAdministrationContent from '@/components/clubs-portal/administration/ClubAdministrationContent';
+import ClubUserDashboardLayout from '@/components/layout/clubs-user-dashboard/ClubUserDashboardLayout';
+
+export default function ClubsPortal() {
+  return (
+    <ClubUserDashboardLayout pageName='Club Administration'>
+      <ClubAdministrationContent />
+    </ClubUserDashboardLayout>
+  );
+}

--- a/src/app/clubs-portal/page.tsx
+++ b/src/app/clubs-portal/page.tsx
@@ -3,7 +3,7 @@ import ClubUserDashboardLayout from '@/components/layout/clubs-user-dashboard/Cl
 
 export default function ClubsPortal() {
   return (
-    <ClubUserDashboardLayout>
+    <ClubUserDashboardLayout showTask>
       <UpcomingEvents />
     </ClubUserDashboardLayout>
   );

--- a/src/components/clubs-portal/UpcomingEvents.tsx
+++ b/src/components/clubs-portal/UpcomingEvents.tsx
@@ -17,7 +17,7 @@ const UpcomingEvents = () => {
         {Object.entries(bookingsGroupedByMonth).map(([month, bookings]) => {
           const date = new Date(parseInt(month));
           return (
-            <>
+            <div key={month}>
               <div className='flex flex-row w-full items-center gap-3 mb-3 sticky top-0 bg-white z-10 shadow-sm'>
                 <h3 className='font-normal shrink-0'>
                   {date.toLocaleDateString('en-US', {
@@ -27,12 +27,12 @@ const UpcomingEvents = () => {
                 </h3>
                 <Divider className='shrink bg-black' />
               </div>
-              <div key={month}>
+              <div>
                 {bookings.map((booking) => (
                   <ClubEvent key={booking.id} booking={booking} />
                 ))}
               </div>
-            </>
+            </div>
           );
         })}
       </div>

--- a/src/components/clubs-portal/admin/ManageClubs.tsx
+++ b/src/components/clubs-portal/admin/ManageClubs.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+
+import Button from '@/components/buttons/Button';
+
+export type ManageClubsButtonProps = {
+  text: string;
+  alignment: 'left' | 'center' | 'right';
+};
+
+export const ManageClubsButton = ({
+  text,
+  alignment,
+}: ManageClubsButtonProps) => {
+  const alignmentOptions = {
+    left: 'ml-auto mr-20',
+    center: 'ml-20 mr-20',
+    right: 'ml-20 mr-auto',
+  };
+  return (
+    <Button
+      size='base'
+      className={`${alignmentOptions[alignment]} mt-20 mb-10 w-1/3 px-2`}
+    >
+      <span className='font-normal not-italic'>{text}</span>
+    </Button>
+  );
+};
+
+export const ManageClubsSection = () => {
+  return (
+    <div className='flex flex-row w-full items-center bg-white'>
+      <ManageClubsButton text='Add A Club' alignment='left' />
+      <ManageClubsButton text='Remove A Club' alignment='center' />
+      <ManageClubsButton text='View All Clubs' alignment='right' />
+    </div>
+  );
+};

--- a/src/components/clubs-portal/admin/UHSForms.tsx
+++ b/src/components/clubs-portal/admin/UHSForms.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const UHSForms = () => {
+  return (
+    <div className='flex items-center px-7 h-280 w-230 bg-gray border-2 rounded-2xl'>
+      <h2>FORM</h2>
+    </div>
+  );
+};
+
+export default UHSForms;

--- a/src/components/clubs-portal/administration/ClubAdministrationContent.tsx
+++ b/src/components/clubs-portal/administration/ClubAdministrationContent.tsx
@@ -20,28 +20,28 @@ const ClubAdministrationContent = () => {
   };
 
   return (
-    <ClubProfileProvider>
-      <TabContext value={tabIndex}>
-        <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
-          <TabList onChange={handleChange}>
-            <Tab label='Club Profile' value='1' />
-            <Tab label='Exec Team' value='2' />
-            <Tab label='Hatch Access Card' value='3' />
-            <Tab label='Governing Docs' value='4' />
-            <Tab label='Recruitment Notice' value='5' />
-          </TabList>
-        </Box>
+    <TabContext value={tabIndex}>
+      <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
+        <TabList onChange={handleChange}>
+          <Tab label='Club Profile' value='1' />
+          <Tab label='Exec Team' value='2' />
+          <Tab label='Hatch Access Card' value='3' />
+          <Tab label='Governing Docs' value='4' />
+          <Tab label='Recruitment Notice' value='5' />
+        </TabList>
+      </Box>
+      <ClubProfileProvider>
         <TabPanel value='1' sx={{ flexBasis: '100%' }}>
           <ClubProfilePanel />
         </TabPanel>
-        <TabPanel value='2'>
-          <ExecTeamPanel />
-        </TabPanel>
-        <TabPanel value='3'>Item Three</TabPanel>
-        <TabPanel value='4'>Item Four</TabPanel>
-        <TabPanel value='5'>Item Five</TabPanel>
-      </TabContext>
-    </ClubProfileProvider>
+      </ClubProfileProvider>
+      <TabPanel value='2'>
+        <ExecTeamPanel />
+      </TabPanel>
+      <TabPanel value='3'>Item Three</TabPanel>
+      <TabPanel value='4'>Item Four</TabPanel>
+      <TabPanel value='5'>Item Five</TabPanel>
+    </TabContext>
   );
 };
 

--- a/src/components/clubs-portal/administration/ClubAdministrationContent.tsx
+++ b/src/components/clubs-portal/administration/ClubAdministrationContent.tsx
@@ -1,11 +1,14 @@
 'use client';
 
-import { TabContext, TabList, TabPanel } from '@mui/lab';
-import { Box, Tab } from '@mui/material';
+import { TabContext } from '@mui/lab';
+import { Box } from '@mui/material';
 import React from 'react';
 
 import ClubProfilePanel from '@/components/clubs-portal/administration/club-profile-panel/ClubProfilePanel';
 import ExecTeamPanel from '@/components/clubs-portal/administration/exec-team/ExecTeamPanel';
+import Tab from '@/components/layout/tab-panel/Tab';
+import TabList from '@/components/layout/tab-panel/TabList';
+import TabPanel from '@/components/layout/tab-panel/TabPanel';
 
 const ClubAdministrationContent = () => {
   const [tabIndex, setTabIndex] = React.useState('1');
@@ -14,56 +17,18 @@ const ClubAdministrationContent = () => {
     setTabIndex(newValue);
   };
 
-  const tabStyle = {
-    '&.Mui-selected': {
-      color: 'var(--color-primary-800)',
-    },
-    '&:hover': {
-      color: 'var(--color-primary-800)',
-    },
-  };
-
   return (
     <TabContext value={tabIndex}>
       <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
-        <TabList
-          onChange={handleChange}
-          TabIndicatorProps={{
-            style: { backgroundColor: 'rgb(var(--tw-color-primary-800))' },
-          }}
-          sx={{
-            //this isnt working for some reason
-            '&.MuiTabs-flexContainer': {
-              justifyContent: 'space-around',
-            },
-          }}
-        >
-          <Tab label='Club Profile' disableRipple sx={tabStyle} value='1' />
-          <Tab label='Exec Team' disableRipple sx={tabStyle} value='2' />
-          <Tab
-            label='Hatch Access Card'
-            disableRipple
-            sx={tabStyle}
-            value='3'
-          />
-          <Tab label='Governing Docs' disableRipple sx={tabStyle} value='4' />
-          <Tab
-            label='Recruitment Notice'
-            disableRipple
-            sx={tabStyle}
-            value='5'
-          />
+        <TabList onChange={handleChange}>
+          <Tab label='Club Profile' value='1' />
+          <Tab label='Exec Team' value='2' />
+          <Tab label='Hatch Access Card' value='3' />
+          <Tab label='Governing Docs' value='4' />
+          <Tab label='Recruitment Notice' value='5' />
         </TabList>
       </Box>
-      <TabPanel
-        value='1'
-        sx={{
-          flexBasis: '100%',
-          overflow: 'hidden',
-          display: 'flex',
-          padding: 0,
-        }}
-      >
+      <TabPanel value='1'>
         <ClubProfilePanel />
       </TabPanel>
       <TabPanel value='2'>

--- a/src/components/clubs-portal/administration/ClubAdministrationContent.tsx
+++ b/src/components/clubs-portal/administration/ClubAdministrationContent.tsx
@@ -4,6 +4,8 @@ import { TabContext } from '@mui/lab';
 import { Box } from '@mui/material';
 import React from 'react';
 
+import { ClubProfileProvider } from '@/lib/context/ClubProfileContext';
+
 import ClubProfilePanel from '@/components/clubs-portal/administration/club-profile-panel/ClubProfilePanel';
 import ExecTeamPanel from '@/components/clubs-portal/administration/exec-team/ExecTeamPanel';
 import Tab from '@/components/layout/tab-panel/Tab';
@@ -29,7 +31,9 @@ const ClubAdministrationContent = () => {
         </TabList>
       </Box>
       <TabPanel value='1' sx={{ flexBasis: '100%' }}>
-        <ClubProfilePanel />
+        <ClubProfileProvider>
+          <ClubProfilePanel />
+        </ClubProfileProvider>
       </TabPanel>
       <TabPanel value='2'>
         <ExecTeamPanel />

--- a/src/components/clubs-portal/administration/ClubAdministrationContent.tsx
+++ b/src/components/clubs-portal/administration/ClubAdministrationContent.tsx
@@ -28,7 +28,7 @@ const ClubAdministrationContent = () => {
           <Tab label='Recruitment Notice' value='5' />
         </TabList>
       </Box>
-      <TabPanel value='1'>
+      <TabPanel value='1' sx={{ flexBasis: '100%' }}>
         <ClubProfilePanel />
       </TabPanel>
       <TabPanel value='2'>

--- a/src/components/clubs-portal/administration/ClubAdministrationContent.tsx
+++ b/src/components/clubs-portal/administration/ClubAdministrationContent.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import { TabContext, TabList, TabPanel } from '@mui/lab';
+import { Box, Tab } from '@mui/material';
+import React from 'react';
+
+import ClubProfilePanel from '@/components/clubs-portal/administration/club-profile-panel/ClubProfilePanel';
+import ExecTeamPanel from '@/components/clubs-portal/administration/exec-team/ExecTeamPanel';
+
+const ClubAdministrationContent = () => {
+  const [tabIndex, setTabIndex] = React.useState('1');
+
+  const handleChange = (event: React.SyntheticEvent, newValue: string) => {
+    setTabIndex(newValue);
+  };
+
+  const tabStyle = {
+    '&.Mui-selected': {
+      color: 'var(--color-primary-800)',
+    },
+    '&:hover': {
+      color: 'var(--color-primary-800)',
+    },
+  };
+
+  return (
+    <TabContext value={tabIndex}>
+      <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
+        <TabList
+          onChange={handleChange}
+          TabIndicatorProps={{
+            style: { backgroundColor: 'rgb(var(--tw-color-primary-800))' },
+          }}
+          sx={{
+            //this isnt working for some reason
+            '&.MuiTabs-flexContainer': {
+              justifyContent: 'space-around',
+            },
+          }}
+        >
+          <Tab label='Club Profile' disableRipple sx={tabStyle} value='1' />
+          <Tab label='Exec Team' disableRipple sx={tabStyle} value='2' />
+          <Tab
+            label='Hatch Access Card'
+            disableRipple
+            sx={tabStyle}
+            value='3'
+          />
+          <Tab label='Governing Docs' disableRipple sx={tabStyle} value='4' />
+          <Tab
+            label='Recruitment Notice'
+            disableRipple
+            sx={tabStyle}
+            value='5'
+          />
+        </TabList>
+      </Box>
+      <TabPanel
+        value='1'
+        sx={{
+          flexBasis: '100%',
+          overflow: 'hidden',
+          display: 'flex',
+          padding: 0,
+        }}
+      >
+        <ClubProfilePanel />
+      </TabPanel>
+      <TabPanel value='2'>
+        <ExecTeamPanel />
+      </TabPanel>
+      <TabPanel value='3'>Item Three</TabPanel>
+      <TabPanel value='4'>Item Four</TabPanel>
+      <TabPanel value='5'>Item Five</TabPanel>
+    </TabContext>
+  );
+};
+
+export default ClubAdministrationContent;

--- a/src/components/clubs-portal/administration/ClubAdministrationContent.tsx
+++ b/src/components/clubs-portal/administration/ClubAdministrationContent.tsx
@@ -20,28 +20,28 @@ const ClubAdministrationContent = () => {
   };
 
   return (
-    <TabContext value={tabIndex}>
-      <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
-        <TabList onChange={handleChange}>
-          <Tab label='Club Profile' value='1' />
-          <Tab label='Exec Team' value='2' />
-          <Tab label='Hatch Access Card' value='3' />
-          <Tab label='Governing Docs' value='4' />
-          <Tab label='Recruitment Notice' value='5' />
-        </TabList>
-      </Box>
-      <TabPanel value='1' sx={{ flexBasis: '100%' }}>
-        <ClubProfileProvider>
+    <ClubProfileProvider>
+      <TabContext value={tabIndex}>
+        <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
+          <TabList onChange={handleChange}>
+            <Tab label='Club Profile' value='1' />
+            <Tab label='Exec Team' value='2' />
+            <Tab label='Hatch Access Card' value='3' />
+            <Tab label='Governing Docs' value='4' />
+            <Tab label='Recruitment Notice' value='5' />
+          </TabList>
+        </Box>
+        <TabPanel value='1' sx={{ flexBasis: '100%' }}>
           <ClubProfilePanel />
-        </ClubProfileProvider>
-      </TabPanel>
-      <TabPanel value='2'>
-        <ExecTeamPanel />
-      </TabPanel>
-      <TabPanel value='3'>Item Three</TabPanel>
-      <TabPanel value='4'>Item Four</TabPanel>
-      <TabPanel value='5'>Item Five</TabPanel>
-    </TabContext>
+        </TabPanel>
+        <TabPanel value='2'>
+          <ExecTeamPanel />
+        </TabPanel>
+        <TabPanel value='3'>Item Three</TabPanel>
+        <TabPanel value='4'>Item Four</TabPanel>
+        <TabPanel value='5'>Item Five</TabPanel>
+      </TabContext>
+    </ClubProfileProvider>
   );
 };
 

--- a/src/components/clubs-portal/administration/club-profile-panel/Box.tsx
+++ b/src/components/clubs-portal/administration/club-profile-panel/Box.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+
+import { cn } from '@/lib/utils';
+
+type BoxProps = {
+  name?: string;
+  children?: React.ReactNode;
+  className?: string;
+};
+
+const Box = ({ name, children, className }: BoxProps) => {
+  return (
+    <>
+      <span className='text-primary-800 font-b'>{name}</span>
+      <div
+        className={cn([
+          className,
+          'flex p-3 border-2 rounded-xl bg-gray-100 border-gray-300 overflow-scroll',
+        ])}
+      >
+        {children}
+      </div>
+    </>
+  );
+};
+
+export default Box;

--- a/src/components/clubs-portal/administration/club-profile-panel/Box.tsx
+++ b/src/components/clubs-portal/administration/club-profile-panel/Box.tsx
@@ -10,17 +10,16 @@ type BoxProps = {
 
 const Box = ({ name, children, className }: BoxProps) => {
   return (
-    <>
+    <div className={cn([className, 'flex flex-col overflow-hidden'])}>
       <span className='text-primary-800 font-b'>{name}</span>
       <div
         className={cn([
-          className,
-          'flex p-3 border-2 rounded-xl bg-gray-100 border-gray-300 overflow-scroll',
+          'flex p-3 basis-full border-2 rounded-xl bg-gray-100 border-gray-300 overflow-scroll',
         ])}
       >
         {children}
       </div>
-    </>
+    </div>
   );
 };
 

--- a/src/components/clubs-portal/administration/club-profile-panel/ClubDescription.tsx
+++ b/src/components/clubs-portal/administration/club-profile-panel/ClubDescription.tsx
@@ -1,0 +1,29 @@
+import { TextField } from '@mui/material';
+import React from 'react';
+
+import { useClubProfileContext } from '@/lib/context/ClubProfileContext';
+
+import Box from '@/components/clubs-portal/administration/club-profile-panel/Box';
+
+const ClubDescription = () => {
+  const { profileData, handleChange } = useClubProfileContext();
+  return (
+    <Box name='Description' className='basis-full'>
+      <TextField
+        multiline
+        fullWidth
+        placeholder='Add a description of your club!'
+        value={profileData.description}
+        onChange={(e) => handleChange('description', e.target.value)}
+        sx={{
+          '& .MuiOutlinedInput-root': {
+            flexBasis: '99%',
+            alignItems: 'flex-start',
+          },
+        }}
+      />
+    </Box>
+  );
+};
+
+export default ClubDescription;

--- a/src/components/clubs-portal/administration/club-profile-panel/ClubDescription.tsx
+++ b/src/components/clubs-portal/administration/club-profile-panel/ClubDescription.tsx
@@ -14,7 +14,7 @@ const ClubDescription = () => {
         fullWidth
         placeholder='Add a description of your club!'
         value={profileData.description}
-        onChange={(e) => handleChange('description', e.target.value)}
+        onChange={(e) => handleChange({ description: e.target.value })}
         sx={{
           '& .MuiOutlinedInput-root': {
             flexBasis: '99%',

--- a/src/components/clubs-portal/administration/club-profile-panel/ClubEmail.tsx
+++ b/src/components/clubs-portal/administration/club-profile-panel/ClubEmail.tsx
@@ -1,0 +1,22 @@
+import { TextField } from '@mui/material';
+import React from 'react';
+
+import { useClubProfileContext } from '@/lib/context/ClubProfileContext';
+
+import Box from '@/components/clubs-portal/administration/club-profile-panel/Box';
+
+const ClubEmail = () => {
+  const { profileData, handleChange } = useClubProfileContext();
+  return (
+    <Box name='Club Email Address' className='shrink-0'>
+      <TextField
+        fullWidth
+        value={profileData.email}
+        placeholder={!profileData.email ? `Add your club's address!` : ''}
+        onChange={(e) => handleChange('email', e.target.value)}
+      />
+    </Box>
+  );
+};
+
+export default ClubEmail;

--- a/src/components/clubs-portal/administration/club-profile-panel/ClubEmail.tsx
+++ b/src/components/clubs-portal/administration/club-profile-panel/ClubEmail.tsx
@@ -13,7 +13,8 @@ const ClubEmail = () => {
         fullWidth
         value={profileData.email}
         placeholder={!profileData.email ? `Add your club's address!` : ''}
-        onChange={(e) => handleChange('email', e.target.value)}
+        onChange={(e) => handleChange({ email: e.target.value })}
+        required
       />
     </Box>
   );

--- a/src/components/clubs-portal/administration/club-profile-panel/ClubProfilePanel.tsx
+++ b/src/components/clubs-portal/administration/club-profile-panel/ClubProfilePanel.tsx
@@ -9,7 +9,7 @@ const ClubProfilePanel = () => {
   return (
     <div className='flex flex-row gap-12 pt-5'>
       <div className='flex flex-col basis-1/3 gap-12'>
-        <Avatar sx={{ height: 175, width: 175 }} className='mx-auto'>
+        <Avatar sx={{ height: 175, width: 175 }} className='mx-auto mt-5'>
           MES
         </Avatar>
         <Box name='Description' className='basis-full'>

--- a/src/components/clubs-portal/administration/club-profile-panel/ClubProfilePanel.tsx
+++ b/src/components/clubs-portal/administration/club-profile-panel/ClubProfilePanel.tsx
@@ -1,58 +1,29 @@
 'use client';
 
-import { Avatar, TextField } from '@mui/material';
 import React from 'react';
 import { FaSave } from 'react-icons/fa';
 
-import {
-  ClubProfileContext,
-  TClubProfileContext,
-} from '@/lib/context/ClubProfileContext';
+import { useClubProfileContext } from '@/lib/context/ClubProfileContext';
 
-import Box from '@/components/clubs-portal/administration/club-profile-panel/Box';
+import ClubDescription from '@/components/clubs-portal/administration/club-profile-panel/ClubDescription';
+import ClubEmail from '@/components/clubs-portal/administration/club-profile-panel/ClubEmail';
+import ClubProfilePicture from '@/components/clubs-portal/administration/club-profile-panel/ClubProfilePicture';
 import SocialsList from '@/components/clubs-portal/administration/club-profile-panel/SocialsList';
 
 const ClubProfilePanel = () => {
-  const { profileData, handleChange, handleSocialChange, handleSocialDelete } =
-    React.useContext(ClubProfileContext) as TClubProfileContext;
+  const { status } = useClubProfileContext();
+  if (status === 'pending') {
+    return <></>;
+  }
   return (
     <div className='flex flex-row gap-12 pt-5 basis-full relative'>
       <div className='flex flex-col basis-1/3 gap-12'>
-        <Avatar sx={{ height: 175, width: 175 }} className='mx-auto mt-5'>
-          MES
-        </Avatar>
-        <Box name='Description' className='basis-full'>
-          <TextField
-            multiline
-            fullWidth
-            placeholder={
-              !profileData.description ? 'Add a description of your club!' : ''
-            }
-            value={profileData.description}
-            onChange={(e) => handleChange('description', e.target.value)}
-            sx={{
-              '& .MuiOutlinedInput-root': {
-                flexBasis: '100%',
-                alignItems: 'flex-start',
-              },
-            }}
-          />
-        </Box>
+        <ClubProfilePicture />
+        <ClubDescription />
       </div>
       <div className='flex flex-col basis-full gap-12'>
-        <Box name='Club Email Address' className='shrink-0'>
-          <TextField
-            fullWidth
-            value={profileData.email}
-            placeholder={!profileData.email ? `Add your club's address!` : ''}
-            onChange={(e) => handleChange('email', e.target.value)}
-          />
-        </Box>
-        <SocialsList
-          socials={profileData.socials}
-          handleSocialChange={handleSocialChange}
-          handleSocialDelete={handleSocialDelete}
-        />
+        <ClubEmail />
+        <SocialsList />
       </div>
       <button className='top-5 left-5 absolute'>
         <FaSave size='40' color='gray' />

--- a/src/components/clubs-portal/administration/club-profile-panel/ClubProfilePanel.tsx
+++ b/src/components/clubs-portal/administration/club-profile-panel/ClubProfilePanel.tsx
@@ -11,12 +11,19 @@ import ClubProfilePicture from '@/components/clubs-portal/administration/club-pr
 import SocialsList from '@/components/clubs-portal/administration/club-profile-panel/SocialsList';
 
 const ClubProfilePanel = () => {
-  const { status } = useClubProfileContext();
+  const { status, handleSave, hasChanges } = useClubProfileContext();
+  const onSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    handleSave();
+  };
   if (status === 'pending') {
     return <></>;
   }
   return (
-    <div className='flex flex-row gap-12 pt-5 basis-full relative'>
+    <form
+      className='flex flex-row gap-12 pt-5 basis-full relative'
+      onSubmit={onSubmit}
+    >
       <div className='flex flex-col basis-1/3 gap-12'>
         <ClubProfilePicture />
         <ClubDescription />
@@ -25,10 +32,21 @@ const ClubProfilePanel = () => {
         <ClubEmail />
         <SocialsList />
       </div>
-      <button className='top-5 left-5 absolute'>
-        <FaSave size='40' color='gray' />
+      <button
+        className='top-5 left-5 absolute'
+        disabled={!hasChanges}
+        type='submit'
+      >
+        <FaSave
+          size='40'
+          color={
+            hasChanges
+              ? 'rgb(var(--tw-color-primary-800))'
+              : 'rgb(var(--tw-color-primary-200))'
+          }
+        />
       </button>
-    </div>
+    </form>
   );
 };
 

--- a/src/components/clubs-portal/administration/club-profile-panel/ClubProfilePanel.tsx
+++ b/src/components/clubs-portal/administration/club-profile-panel/ClubProfilePanel.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { CircularProgress } from '@mui/material';
 import React from 'react';
 import { FaSave } from 'react-icons/fa';
 
@@ -11,13 +12,13 @@ import ClubProfilePicture from '@/components/clubs-portal/administration/club-pr
 import SocialsList from '@/components/clubs-portal/administration/club-profile-panel/SocialsList';
 
 const ClubProfilePanel = () => {
-  const { status, handleSave, hasChanges } = useClubProfileContext();
+  const { isLoading, handleSave, hasChanges } = useClubProfileContext();
   const onSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     handleSave().then((message) => alert(message));
   };
-  if (status === 'pending') {
-    return <></>;
+  if (isLoading) {
+    return <CircularProgress className='m-auto' />;
   }
   return (
     <form

--- a/src/components/clubs-portal/administration/club-profile-panel/ClubProfilePanel.tsx
+++ b/src/components/clubs-portal/administration/club-profile-panel/ClubProfilePanel.tsx
@@ -12,11 +12,19 @@ import ClubProfilePicture from '@/components/clubs-portal/administration/club-pr
 import SocialsList from '@/components/clubs-portal/administration/club-profile-panel/SocialsList';
 
 const ClubProfilePanel = () => {
-  const { isLoading, handleSave, hasChanges } = useClubProfileContext();
+  const { isError, isLoading, handleSave, hasChanges } =
+    useClubProfileContext();
   const onSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     handleSave().then((message) => alert(message));
   };
+  if (isError) {
+    return (
+      <div className='m-auto font-bold text-lg'>
+        There was an error loading your club's profile. Contact support
+      </div>
+    );
+  }
   if (isLoading) {
     return <CircularProgress className='m-auto' />;
   }

--- a/src/components/clubs-portal/administration/club-profile-panel/ClubProfilePanel.tsx
+++ b/src/components/clubs-portal/administration/club-profile-panel/ClubProfilePanel.tsx
@@ -1,0 +1,68 @@
+import { Avatar } from '@mui/material';
+import React from 'react';
+
+import Box from '@/components/clubs-portal/administration/club-profile-panel/Box';
+import Social from '@/components/clubs-portal/administration/club-profile-panel/Social';
+
+const ClubProfilePanel = () => {
+  const [email, setEmail] = React.useState('current_address@mcmaster.ca');
+  return (
+    <div className='flex flex-row gap-12'>
+      <div className='flex flex-col basis-1/3'>
+        <Avatar sx={{ height: 175, width: 175 }} className='m-auto'>
+          MES
+        </Avatar>
+        <Box name='Description' className='basis-1/2'>
+          Lorem ipsum odor amet, consectetuer adipiscing elit. Sit nullam fusce
+          ligula massa dignissim integer. At efficitur curabitur eleifend
+          maecenas hendrerit; molestie egestas. Natoque elit sagittis mi ipsum
+          pretium metus per. Litora egestas sociosqu, turpis fames faucibus
+          consectetur eleifend. Lorem ipsum dolor sit amet consectetur
+          adipisicing elit. Omnis praesentium assumenda excepturi, aliquid
+          consequatur, voluptatum cupiditate veniam eveniet tempora, mollitia
+          libero eos quidem itaque vel alias quisquam. Facere, facilis officiis!
+        </Box>
+      </div>
+      <div className='flex flex-col basis-full justify-around gap-12'>
+        <Box name='Club Email Address' className='items-center'>
+          <input
+            type='text'
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            className='border-none p-0 focus:ring-0 outline-none bg-transparent w-full'
+          />
+        </Box>
+        <Box name='Social Media'>
+          <div className='flex flex-col gap-2 w-full'>
+            <Social name='instagram' value='@mesmac' />
+            <Social name='discord' value='discord.gg/mesmac' />
+            <Social name='linkedin' value='linkedin.com/mesmac' />
+            <Social name='facebook' value='facebook.com/mesmac' />
+            <Social name='website' value='mesmac.ca' />
+          </div>
+        </Box>
+      </div>
+    </div>
+  );
+};
+
+type _ClubProfile = {
+  id: string;
+  name: string;
+  log: string;
+  email: string;
+  description: string;
+  website: string;
+  instagram: string;
+  facebook: string;
+  linkedin: string;
+  twitter: string;
+  youtube: string;
+  linktree: string;
+  github: string;
+  tiktok: string;
+  discord: string;
+  mailingList: string;
+};
+
+export default ClubProfilePanel;

--- a/src/components/clubs-portal/administration/club-profile-panel/ClubProfilePanel.tsx
+++ b/src/components/clubs-portal/administration/club-profile-panel/ClubProfilePanel.tsx
@@ -2,46 +2,21 @@
 
 import { Avatar, TextField } from '@mui/material';
 import React from 'react';
+import { FaSave } from 'react-icons/fa';
+
+import {
+  ClubProfileContext,
+  TClubProfileContext,
+} from '@/lib/context/ClubProfileContext';
 
 import Box from '@/components/clubs-portal/administration/club-profile-panel/Box';
 import SocialsList from '@/components/clubs-portal/administration/club-profile-panel/SocialsList';
 
-import { SocialMedia } from '@/types/clubProfile';
-
 const ClubProfilePanel = () => {
-  const [profileData, setProfileData] = React.useState({
-    profilePicture: '',
-    email: '',
-    description: '',
-    socialMedia: {} as Record<SocialMedia, string>,
-  });
-
-  React.useEffect(() => {
-    const fetchData = async () => {
-      const data = await fetchUserData();
-      setProfileData(data);
-    };
-    fetchData();
-  }, []);
-
-  const handleChange = (field: string, value: string) => {
-    setProfileData((prevData) => ({
-      ...prevData,
-      [field]: value,
-    }));
-  };
-
-  const handleSocialChange = (name: SocialMedia, value: string) => {
-    const updatedSocialMedia = profileData.socialMedia;
-    updatedSocialMedia[name] = value;
-    setProfileData((prevData) => ({
-      ...prevData,
-      socialMedia: updatedSocialMedia,
-    }));
-  };
-
+  const { profileData, handleChange, handleSocialChange, handleSocialDelete } =
+    React.useContext(ClubProfileContext) as TClubProfileContext;
   return (
-    <div className='flex flex-row gap-12 pt-5 basis-full'>
+    <div className='flex flex-row gap-12 pt-5 basis-full relative'>
       <div className='flex flex-col basis-1/3 gap-12'>
         <Avatar sx={{ height: 175, width: 175 }} className='mx-auto mt-5'>
           MES
@@ -74,26 +49,16 @@ const ClubProfilePanel = () => {
           />
         </Box>
         <SocialsList
-          socials={profileData.socialMedia}
+          socials={profileData.socials}
           handleSocialChange={handleSocialChange}
+          handleSocialDelete={handleSocialDelete}
         />
       </div>
+      <button className='top-5 left-5 absolute'>
+        <FaSave size='40' color='gray' />
+      </button>
     </div>
   );
 };
 
 export default ClubProfilePanel;
-
-const fetchUserData = async () => {
-  return {
-    profilePicture: '',
-    email: '', //'current_address@mcmaster.ca',
-    description: '', //'Lorem ipsum dolor sit amet consectetur, adipisicing elit. Accusamus totam non iusto sapiente! Veritatis rerum consequuntur fugiat inventore sapiente porro labore laudantium minus iure. Consequatur vel nihil iusto odit nisi?',
-    socialMedia: {
-      instagram: '@mcmasterengsoc',
-      discord: 'McMaster Engineering Society',
-      linkedin: 'McMaster Engineering Society',
-      facebook: 'McMaster Engineering Society',
-    } as Record<SocialMedia, string>,
-  };
-};

--- a/src/components/clubs-portal/administration/club-profile-panel/ClubProfilePanel.tsx
+++ b/src/components/clubs-portal/administration/club-profile-panel/ClubProfilePanel.tsx
@@ -14,7 +14,7 @@ const ClubProfilePanel = () => {
   const { status, handleSave, hasChanges } = useClubProfileContext();
   const onSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    handleSave();
+    handleSave().then((message) => alert(message));
   };
   if (status === 'pending') {
     return <></>;

--- a/src/components/clubs-portal/administration/club-profile-panel/ClubProfilePanel.tsx
+++ b/src/components/clubs-portal/administration/club-profile-panel/ClubProfilePanel.tsx
@@ -7,12 +7,12 @@ import Social from '@/components/clubs-portal/administration/club-profile-panel/
 const ClubProfilePanel = () => {
   const [email, setEmail] = React.useState('current_address@mcmaster.ca');
   return (
-    <div className='flex flex-row gap-12'>
-      <div className='flex flex-col basis-1/3'>
-        <Avatar sx={{ height: 175, width: 175 }} className='m-auto'>
+    <div className='flex flex-row gap-12 pt-5'>
+      <div className='flex flex-col basis-1/3 gap-12'>
+        <Avatar sx={{ height: 175, width: 175 }} className='mx-auto'>
           MES
         </Avatar>
-        <Box name='Description' className='basis-1/2'>
+        <Box name='Description' className='basis-full'>
           Lorem ipsum odor amet, consectetuer adipiscing elit. Sit nullam fusce
           ligula massa dignissim integer. At efficitur curabitur eleifend
           maecenas hendrerit; molestie egestas. Natoque elit sagittis mi ipsum
@@ -23,8 +23,8 @@ const ClubProfilePanel = () => {
           libero eos quidem itaque vel alias quisquam. Facere, facilis officiis!
         </Box>
       </div>
-      <div className='flex flex-col basis-full justify-around gap-12'>
-        <Box name='Club Email Address' className='items-center'>
+      <div className='flex flex-col basis-full gap-12'>
+        <Box name='Club Email Address' className='shrink-0'>
           <input
             type='text'
             value={email}
@@ -32,7 +32,7 @@ const ClubProfilePanel = () => {
             className='border-none p-0 focus:ring-0 outline-none bg-transparent w-full'
           />
         </Box>
-        <Box name='Social Media'>
+        <Box name='Social Media' className='basis-full'>
           <div className='flex flex-col gap-2 w-full'>
             <Social name='instagram' value='@mesmac' />
             <Social name='discord' value='discord.gg/mesmac' />

--- a/src/components/clubs-portal/administration/club-profile-panel/ClubProfilePanel.tsx
+++ b/src/components/clubs-portal/administration/club-profile-panel/ClubProfilePanel.tsx
@@ -1,44 +1,92 @@
-import { Avatar } from '@mui/material';
+'use client';
+
+import { Avatar, TextField } from '@mui/material';
 import React from 'react';
 
 import Box from '@/components/clubs-portal/administration/club-profile-panel/Box';
 import Social from '@/components/clubs-portal/administration/club-profile-panel/Social';
 
+import { SocialMedia } from '@/types/clubProfile';
+
 const ClubProfilePanel = () => {
-  const [email, setEmail] = React.useState('current_address@mcmaster.ca');
+  const [profileData, setProfileData] = React.useState({
+    profilePicture: '',
+    email: '',
+    description: '',
+    socialMedia: {} as Record<SocialMedia, string>,
+  });
+
+  React.useEffect(() => {
+    const fetchData = async () => {
+      const data = await fetchUserData();
+      setProfileData(data);
+    };
+    fetchData();
+  }, []);
+
+  const handleChange = (field: string, value: string) => {
+    setProfileData((prevData) => ({
+      ...prevData,
+      [field]: value,
+    }));
+  };
+
+  const handleSocialChange = (name: SocialMedia, value: string) => {
+    const updatedSocialMedia = profileData.socialMedia;
+    updatedSocialMedia[name] = value;
+    setProfileData((prevData) => ({
+      ...prevData,
+      socialMedia: updatedSocialMedia,
+    }));
+  };
+
   return (
-    <div className='flex flex-row gap-12 pt-5'>
+    <div className='flex flex-row gap-12 pt-5 basis-full'>
       <div className='flex flex-col basis-1/3 gap-12'>
         <Avatar sx={{ height: 175, width: 175 }} className='mx-auto mt-5'>
           MES
         </Avatar>
         <Box name='Description' className='basis-full'>
-          Lorem ipsum odor amet, consectetuer adipiscing elit. Sit nullam fusce
-          ligula massa dignissim integer. At efficitur curabitur eleifend
-          maecenas hendrerit; molestie egestas. Natoque elit sagittis mi ipsum
-          pretium metus per. Litora egestas sociosqu, turpis fames faucibus
-          consectetur eleifend. Lorem ipsum dolor sit amet consectetur
-          adipisicing elit. Omnis praesentium assumenda excepturi, aliquid
-          consequatur, voluptatum cupiditate veniam eveniet tempora, mollitia
-          libero eos quidem itaque vel alias quisquam. Facere, facilis officiis!
+          <TextField
+            multiline
+            fullWidth
+            placeholder={
+              !profileData.description ? 'Add a description of your club!' : ''
+            }
+            value={profileData.description}
+            onChange={(e) => handleChange('description', e.target.value)}
+            sx={{
+              '& .MuiOutlinedInput-root': {
+                flexBasis: '100%',
+                alignItems: 'flex-start',
+              },
+            }}
+          />
         </Box>
       </div>
       <div className='flex flex-col basis-full gap-12'>
         <Box name='Club Email Address' className='shrink-0'>
-          <input
-            type='text'
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            className='border-none p-0 focus:ring-0 outline-none bg-transparent w-full'
+          <TextField
+            fullWidth
+            value={profileData.email}
+            placeholder={!profileData.email ? `Add your club's address!` : ''}
+            onChange={(e) => handleChange('email', e.target.value)}
           />
         </Box>
         <Box name='Social Media' className='basis-full'>
           <div className='flex flex-col gap-2 w-full'>
-            <Social name='instagram' value='@mesmac' />
-            <Social name='discord' value='discord.gg/mesmac' />
-            <Social name='linkedin' value='linkedin.com/mesmac' />
-            <Social name='facebook' value='facebook.com/mesmac' />
-            <Social name='website' value='mesmac.ca' />
+            {Object.entries(profileData.socialMedia).length > 0 ? (
+              Object.entries(profileData.socialMedia).map(([name, value]) => (
+                <Social
+                  key={name}
+                  name={name as SocialMedia}
+                  value={value}
+                  onChange={handleSocialChange}
+                />
+              ))
+            ) : (
+              <p>No social media added yet.</p>
+            )}
           </div>
         </Box>
       </div>
@@ -46,23 +94,18 @@ const ClubProfilePanel = () => {
   );
 };
 
-type _ClubProfile = {
-  id: string;
-  name: string;
-  log: string;
-  email: string;
-  description: string;
-  website: string;
-  instagram: string;
-  facebook: string;
-  linkedin: string;
-  twitter: string;
-  youtube: string;
-  linktree: string;
-  github: string;
-  tiktok: string;
-  discord: string;
-  mailingList: string;
-};
-
 export default ClubProfilePanel;
+
+const fetchUserData = async () => {
+  return {
+    profilePicture: '',
+    email: '', //'current_address@mcmaster.ca',
+    description: '', //'Lorem ipsum dolor sit amet consectetur, adipisicing elit. Accusamus totam non iusto sapiente! Veritatis rerum consequuntur fugiat inventore sapiente porro labore laudantium minus iure. Consequatur vel nihil iusto odit nisi?',
+    socialMedia: {
+      instagram: '@mcmasterengsoc',
+      discord: 'McMaster Engineering Society',
+      linkedin: 'McMaster Engineering Society',
+      facebook: 'McMaster Engineering Society',
+    } as Record<SocialMedia, string>,
+  };
+};

--- a/src/components/clubs-portal/administration/club-profile-panel/ClubProfilePanel.tsx
+++ b/src/components/clubs-portal/administration/club-profile-panel/ClubProfilePanel.tsx
@@ -4,7 +4,7 @@ import { Avatar, TextField } from '@mui/material';
 import React from 'react';
 
 import Box from '@/components/clubs-portal/administration/club-profile-panel/Box';
-import Social from '@/components/clubs-portal/administration/club-profile-panel/Social';
+import SocialsList from '@/components/clubs-portal/administration/club-profile-panel/SocialsList';
 
 import { SocialMedia } from '@/types/clubProfile';
 
@@ -73,22 +73,10 @@ const ClubProfilePanel = () => {
             onChange={(e) => handleChange('email', e.target.value)}
           />
         </Box>
-        <Box name='Social Media' className='basis-full'>
-          <div className='flex flex-col gap-2 w-full'>
-            {Object.entries(profileData.socialMedia).length > 0 ? (
-              Object.entries(profileData.socialMedia).map(([name, value]) => (
-                <Social
-                  key={name}
-                  name={name as SocialMedia}
-                  value={value}
-                  onChange={handleSocialChange}
-                />
-              ))
-            ) : (
-              <p>No social media added yet.</p>
-            )}
-          </div>
-        </Box>
+        <SocialsList
+          socials={profileData.socialMedia}
+          handleSocialChange={handleSocialChange}
+        />
       </div>
     </div>
   );

--- a/src/components/clubs-portal/administration/club-profile-panel/ClubProfilePicture.tsx
+++ b/src/components/clubs-portal/administration/club-profile-panel/ClubProfilePicture.tsx
@@ -1,0 +1,12 @@
+import { Avatar } from '@mui/material';
+import React from 'react';
+
+const ClubProfilePicture = () => {
+  return (
+    <Avatar sx={{ height: 175, width: 175 }} className='mx-auto mt-5'>
+      MES
+    </Avatar>
+  );
+};
+
+export default ClubProfilePicture;

--- a/src/components/clubs-portal/administration/club-profile-panel/Social.tsx
+++ b/src/components/clubs-portal/administration/club-profile-panel/Social.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { TextField } from '@mui/material';
-import React from 'react';
+import React, { useContext } from 'react';
 import {
   FaDiscord,
   FaFacebook,
@@ -18,6 +18,11 @@ import {
 import { IoCloseOutline } from 'react-icons/io5';
 import { IconType } from 'react-icons/lib';
 
+import {
+  ClubProfileContext,
+  TClubProfileContext,
+} from '@/lib/context/ClubProfileContext';
+
 import Box from '@/components/clubs-portal/administration/club-profile-panel/Box';
 
 import { SocialMedia } from '@/types/clubProfile';
@@ -25,11 +30,12 @@ import { SocialMedia } from '@/types/clubProfile';
 type SocialProps = {
   name: SocialMedia;
   value: string;
-  onChange: (name: SocialMedia, value: string) => void;
-  handleDelete: (name: SocialMedia) => void;
 };
 
-const Social = ({ name, value, onChange, handleDelete }: SocialProps) => {
+const Social = ({ name, value }: SocialProps) => {
+  const { handleSocialChange, handleSocialDelete } = useContext(
+    ClubProfileContext,
+  ) as TClubProfileContext;
   const Icon = socialIcons[name];
   return (
     <div className='flex flex-row items-center w-full'>
@@ -38,12 +44,12 @@ const Social = ({ name, value, onChange, handleDelete }: SocialProps) => {
         <TextField
           fullWidth
           value={value}
-          onChange={(e) => onChange(name, e.target.value)}
+          onChange={(e) => handleSocialChange(name, e.target.value)}
         />
       </Box>
       <button
         onClick={() => {
-          handleDelete(name);
+          handleSocialDelete(name);
         }}
       >
         <IoCloseOutline className='ml-2' size='40' color='red' />

--- a/src/components/clubs-portal/administration/club-profile-panel/Social.tsx
+++ b/src/components/clubs-portal/administration/club-profile-panel/Social.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import React from 'react';
+import { FaInstagramSquare } from 'react-icons/fa';
+import { FaDiscord } from 'react-icons/fa';
+import { FaLinkedin } from 'react-icons/fa';
+import { FaGlobe } from 'react-icons/fa';
+import { FaFacebook } from 'react-icons/fa';
+import { IconType } from 'react-icons/lib';
+
+import Box from '@/components/clubs-portal/administration/club-profile-panel/Box';
+
+type SocialProps = {
+  name: string;
+  value: string;
+};
+
+const Social = ({ name, value }: SocialProps) => {
+  const Icon = socialIcons[name];
+  return (
+    <div className='flex flex-row items-center w-full'>
+      <Icon className='mr-2' size='40' />
+      <Box className='items-center w-full'>
+        <input
+          type='text'
+          value={value}
+          className='border-none p-0 focus:ring-0 outline-none bg-transparent w-full'
+        />
+      </Box>
+    </div>
+  );
+};
+
+export default Social;
+
+export const socialIcons: Record<string, IconType> = {
+  instagram: FaInstagramSquare,
+  discord: FaDiscord,
+  linkedin: FaLinkedin,
+  facebook: FaFacebook,
+  website: FaGlobe,
+};

--- a/src/components/clubs-portal/administration/club-profile-panel/Social.tsx
+++ b/src/components/clubs-portal/administration/club-profile-panel/Social.tsx
@@ -15,6 +15,7 @@ import {
   FaTwitter,
   FaYoutube,
 } from 'react-icons/fa';
+import { IoCloseOutline } from 'react-icons/io5';
 import { IconType } from 'react-icons/lib';
 
 import Box from '@/components/clubs-portal/administration/club-profile-panel/Box';
@@ -25,9 +26,10 @@ type SocialProps = {
   name: SocialMedia;
   value: string;
   onChange: (name: SocialMedia, value: string) => void;
+  handleDelete: (name: SocialMedia) => void;
 };
 
-const Social = ({ name, value, onChange }: SocialProps) => {
+const Social = ({ name, value, onChange, handleDelete }: SocialProps) => {
   const Icon = socialIcons[name];
   return (
     <div className='flex flex-row items-center w-full'>
@@ -39,6 +41,13 @@ const Social = ({ name, value, onChange }: SocialProps) => {
           onChange={(e) => onChange(name, e.target.value)}
         />
       </Box>
+      <button
+        onClick={() => {
+          handleDelete(name);
+        }}
+      >
+        <IoCloseOutline className='ml-2' size='40' color='red' />
+      </button>
     </div>
   );
 };

--- a/src/components/clubs-portal/administration/club-profile-panel/Social.tsx
+++ b/src/components/clubs-portal/administration/club-profile-panel/Social.tsx
@@ -20,7 +20,7 @@ const Social = ({ name, value }: SocialProps) => {
   return (
     <div className='flex flex-row items-center w-full'>
       <Icon className='mr-2' size='40' />
-      <Box className='items-center w-full'>
+      <Box className='w-full'>
         <input
           type='text'
           value={value}

--- a/src/components/clubs-portal/administration/club-profile-panel/Social.tsx
+++ b/src/components/clubs-portal/administration/club-profile-panel/Social.tsx
@@ -2,11 +2,19 @@
 
 import { TextField } from '@mui/material';
 import React from 'react';
-import { FaInstagramSquare } from 'react-icons/fa';
-import { FaDiscord } from 'react-icons/fa';
-import { FaLinkedin } from 'react-icons/fa';
-import { FaGlobe } from 'react-icons/fa';
-import { FaFacebook } from 'react-icons/fa';
+import {
+  FaDiscord,
+  FaFacebook,
+  FaGithub,
+  FaGlobe,
+  FaInstagramSquare,
+  FaLinkedin,
+  FaMailBulk,
+  FaTiktok,
+  FaTree,
+  FaTwitter,
+  FaYoutube,
+} from 'react-icons/fa';
 import { IconType } from 'react-icons/lib';
 
 import Box from '@/components/clubs-portal/administration/club-profile-panel/Box';
@@ -24,7 +32,7 @@ const Social = ({ name, value, onChange }: SocialProps) => {
   return (
     <div className='flex flex-row items-center w-full'>
       <Icon className='mr-2' size='40' />
-      <Box className='w-full pb-3'>
+      <Box className='w-full'>
         <TextField
           fullWidth
           value={value}
@@ -43,10 +51,10 @@ export const socialIcons: Record<SocialMedia, IconType> = {
   linkedin: FaLinkedin,
   facebook: FaFacebook,
   website: FaGlobe,
-  github: FaGlobe, //place holder globes
-  twitter: FaGlobe,
-  youtube: FaGlobe,
-  linktree: FaGlobe,
-  tiktok: FaGlobe,
-  mailingList: FaGlobe,
+  github: FaGithub,
+  twitter: FaTwitter,
+  youtube: FaYoutube,
+  linktree: FaTree, //update
+  tiktok: FaTiktok,
+  mailingList: FaMailBulk, //update
 };

--- a/src/components/clubs-portal/administration/club-profile-panel/Social.tsx
+++ b/src/components/clubs-portal/administration/club-profile-panel/Social.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { TextField } from '@mui/material';
-import React, { useContext } from 'react';
+import React from 'react';
 import {
   FaDiscord,
   FaFacebook,
@@ -18,11 +18,6 @@ import {
 import { IoCloseOutline } from 'react-icons/io5';
 import { IconType } from 'react-icons/lib';
 
-import {
-  ClubProfileContext,
-  TClubProfileContext,
-} from '@/lib/context/ClubProfileContext';
-
 import Box from '@/components/clubs-portal/administration/club-profile-panel/Box';
 
 import { SocialMedia } from '@/types/clubProfile';
@@ -30,13 +25,12 @@ import { SocialMedia } from '@/types/clubProfile';
 type SocialProps = {
   name: SocialMedia;
   value: string;
+  handleChange: (name: SocialMedia, value?: string | null) => void;
 };
 
-const Social = ({ name, value }: SocialProps) => {
-  const { handleSocialChange, handleSocialDelete } = useContext(
-    ClubProfileContext,
-  ) as TClubProfileContext;
+const Social = ({ name, value, handleChange }: SocialProps) => {
   const Icon = socialIcons[name];
+
   return (
     <div className='flex flex-row items-center w-full'>
       <Icon className='mr-2' size='40' />
@@ -44,13 +38,15 @@ const Social = ({ name, value }: SocialProps) => {
         <TextField
           fullWidth
           value={value}
-          onChange={(e) => handleSocialChange(name, e.target.value)}
+          onChange={(e) => handleChange(name, e.target.value)}
+          required
         />
       </Box>
       <button
         onClick={() => {
-          handleSocialDelete(name);
+          handleChange(name);
         }}
+        type='button'
       >
         <IoCloseOutline className='ml-2' size='40' color='red' />
       </button>

--- a/src/components/clubs-portal/administration/club-profile-panel/Social.tsx
+++ b/src/components/clubs-portal/administration/club-profile-panel/Social.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { TextField } from '@mui/material';
 import React from 'react';
 import { FaInstagramSquare } from 'react-icons/fa';
 import { FaDiscord } from 'react-icons/fa';
@@ -10,21 +11,24 @@ import { IconType } from 'react-icons/lib';
 
 import Box from '@/components/clubs-portal/administration/club-profile-panel/Box';
 
+import { SocialMedia } from '@/types/clubProfile';
+
 type SocialProps = {
-  name: string;
+  name: SocialMedia;
   value: string;
+  onChange: (name: SocialMedia, value: string) => void;
 };
 
-const Social = ({ name, value }: SocialProps) => {
+const Social = ({ name, value, onChange }: SocialProps) => {
   const Icon = socialIcons[name];
   return (
     <div className='flex flex-row items-center w-full'>
       <Icon className='mr-2' size='40' />
-      <Box className='w-full'>
-        <input
-          type='text'
+      <Box className='w-full pb-3'>
+        <TextField
+          fullWidth
           value={value}
-          className='border-none p-0 focus:ring-0 outline-none bg-transparent w-full'
+          onChange={(e) => onChange(name, e.target.value)}
         />
       </Box>
     </div>
@@ -33,10 +37,16 @@ const Social = ({ name, value }: SocialProps) => {
 
 export default Social;
 
-export const socialIcons: Record<string, IconType> = {
+export const socialIcons: Record<SocialMedia, IconType> = {
   instagram: FaInstagramSquare,
   discord: FaDiscord,
   linkedin: FaLinkedin,
   facebook: FaFacebook,
   website: FaGlobe,
+  github: FaGlobe, //place holder globes
+  twitter: FaGlobe,
+  youtube: FaGlobe,
+  linktree: FaGlobe,
+  tiktok: FaGlobe,
+  mailingList: FaGlobe,
 };

--- a/src/components/clubs-portal/administration/club-profile-panel/SocialsList.tsx
+++ b/src/components/clubs-portal/administration/club-profile-panel/SocialsList.tsx
@@ -1,10 +1,7 @@
 import { Popover } from '@mui/material';
-import React, { useContext, useState } from 'react';
+import React, { useState } from 'react';
 
-import {
-  ClubProfileContext,
-  TClubProfileContext,
-} from '@/lib/context/ClubProfileContext';
+import { useClubProfileContext } from '@/lib/context/ClubProfileContext';
 import { cn } from '@/lib/utils';
 
 import Button from '@/components/buttons/Button';
@@ -16,12 +13,20 @@ import Social, {
 import { SocialMedia } from '@/types/clubProfile';
 
 const SocialsList = () => {
-  const { profileData, handleSocialChange } = useContext(
-    ClubProfileContext,
-  ) as TClubProfileContext;
+  const { profileData, handleChange } = useClubProfileContext();
   const { socials } = profileData;
   const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null);
 
+  const handleSocialChange = (
+    name: SocialMedia,
+    value: string | null = null,
+  ) => {
+    const updatedSocials = { ...socials, [name]: value };
+    if (value === null) {
+      delete updatedSocials[name];
+    }
+    handleChange({ socials: updatedSocials });
+  };
   const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
     setAnchorEl(event.currentTarget);
   };
@@ -38,7 +43,12 @@ const SocialsList = () => {
       <div className='flex flex-col gap-2 w-full'>
         {Object.entries(socials).length > 0 ? (
           Object.entries(socials).map(([name, value]) => (
-            <Social key={name} name={name as SocialMedia} value={value} />
+            <Social
+              key={name}
+              name={name as SocialMedia}
+              value={value}
+              handleChange={handleSocialChange}
+            />
           ))
         ) : (
           <p className='m-auto mb-0'>No social media added yet.</p>

--- a/src/components/clubs-portal/administration/club-profile-panel/SocialsList.tsx
+++ b/src/components/clubs-portal/administration/club-profile-panel/SocialsList.tsx
@@ -1,6 +1,10 @@
 import { Popover } from '@mui/material';
-import React from 'react';
+import React, { useContext, useState } from 'react';
 
+import {
+  ClubProfileContext,
+  TClubProfileContext,
+} from '@/lib/context/ClubProfileContext';
 import { cn } from '@/lib/utils';
 
 import Button from '@/components/buttons/Button';
@@ -11,20 +15,12 @@ import Social, {
 
 import { SocialMedia } from '@/types/clubProfile';
 
-type SocialsListProps = {
-  socials: Record<SocialMedia, string>;
-  handleSocialChange: (name: SocialMedia, value: string) => void;
-  handleSocialDelete: (name: SocialMedia) => void;
-};
-
-const SocialsList = ({
-  socials,
-  handleSocialChange,
-  handleSocialDelete,
-}: SocialsListProps) => {
-  const [anchorEl, setAnchorEl] = React.useState<HTMLButtonElement | null>(
-    null,
-  );
+const SocialsList = () => {
+  const { profileData, handleSocialChange } = useContext(
+    ClubProfileContext,
+  ) as TClubProfileContext;
+  const { socials } = profileData;
+  const [anchorEl, setAnchorEl] = useState<HTMLButtonElement | null>(null);
 
   const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
     setAnchorEl(event.currentTarget);
@@ -42,13 +38,7 @@ const SocialsList = ({
       <div className='flex flex-col gap-2 w-full'>
         {Object.entries(socials).length > 0 ? (
           Object.entries(socials).map(([name, value]) => (
-            <Social
-              key={name}
-              name={name as SocialMedia}
-              value={value}
-              onChange={handleSocialChange}
-              handleDelete={handleSocialDelete}
-            />
+            <Social key={name} name={name as SocialMedia} value={value} />
           ))
         ) : (
           <p className='m-auto mb-0'>No social media added yet.</p>

--- a/src/components/clubs-portal/administration/club-profile-panel/SocialsList.tsx
+++ b/src/components/clubs-portal/administration/club-profile-panel/SocialsList.tsx
@@ -14,9 +14,14 @@ import { SocialMedia } from '@/types/clubProfile';
 type SocialsListProps = {
   socials: Record<SocialMedia, string>;
   handleSocialChange: (name: SocialMedia, value: string) => void;
+  handleSocialDelete: (name: SocialMedia) => void;
 };
 
-const SocialsList = ({ socials, handleSocialChange }: SocialsListProps) => {
+const SocialsList = ({
+  socials,
+  handleSocialChange,
+  handleSocialDelete,
+}: SocialsListProps) => {
   const [anchorEl, setAnchorEl] = React.useState<HTMLButtonElement | null>(
     null,
   );
@@ -42,6 +47,7 @@ const SocialsList = ({ socials, handleSocialChange }: SocialsListProps) => {
               name={name as SocialMedia}
               value={value}
               onChange={handleSocialChange}
+              handleDelete={handleSocialDelete}
             />
           ))
         ) : (

--- a/src/components/clubs-portal/administration/club-profile-panel/SocialsList.tsx
+++ b/src/components/clubs-portal/administration/club-profile-panel/SocialsList.tsx
@@ -1,0 +1,98 @@
+import { Popover } from '@mui/material';
+import React from 'react';
+
+import { cn } from '@/lib/utils';
+
+import Button from '@/components/buttons/Button';
+import Box from '@/components/clubs-portal/administration/club-profile-panel/Box';
+import Social, {
+  socialIcons,
+} from '@/components/clubs-portal/administration/club-profile-panel/Social';
+
+import { SocialMedia } from '@/types/clubProfile';
+
+type SocialsListProps = {
+  socials: Record<SocialMedia, string>;
+  handleSocialChange: (name: SocialMedia, value: string) => void;
+};
+
+const SocialsList = ({ socials, handleSocialChange }: SocialsListProps) => {
+  const [anchorEl, setAnchorEl] = React.useState<HTMLButtonElement | null>(
+    null,
+  );
+
+  const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
+  const open = Boolean(anchorEl);
+  const unaddedSocialsList = unaddedSocials(socials);
+
+  return (
+    <Box name='Social Media' className='basis-full'>
+      <div className='flex flex-col gap-2 w-full'>
+        {Object.entries(socials).length > 0 ? (
+          Object.entries(socials).map(([name, value]) => (
+            <Social
+              key={name}
+              name={name as SocialMedia}
+              value={value}
+              onChange={handleSocialChange}
+            />
+          ))
+        ) : (
+          <p className='m-auto mb-0'>No social media added yet.</p>
+        )}
+        <Popover
+          open={open}
+          anchorEl={anchorEl}
+          onClose={handleClose}
+          anchorOrigin={{
+            vertical: 'top',
+            horizontal: 'center',
+          }}
+          transformOrigin={{
+            vertical: 'bottom',
+            horizontal: 'center',
+          }}
+        >
+          {unaddedSocialsList.map((social) => {
+            const SocialIcon = socialIcons[social];
+            return (
+              <button
+                key={social}
+                onClick={() => {
+                  handleSocialChange(social as SocialMedia, '');
+                  handleClose();
+                }}
+              >
+                <SocialIcon size='40' />
+              </button>
+            );
+          })}
+        </Popover>
+        <Button
+          className={cn([
+            'w-52 ml-auto',
+            Object.keys(socials).length === 0 && 'm-auto mt-0',
+          ])}
+          onClick={handleClick}
+        >
+          Add Social Media
+        </Button>
+      </div>
+    </Box>
+  );
+};
+
+export default SocialsList;
+
+function unaddedSocials(socials: Record<SocialMedia, string>) {
+  const allSocials = Object.keys(socialIcons) as SocialMedia[];
+  const existingSocials = Object.keys(socials) as SocialMedia[];
+  return allSocials.filter((social) => !existingSocials.includes(social));
+}

--- a/src/components/clubs-portal/administration/exec-team/ExecTeamPanel.tsx
+++ b/src/components/clubs-portal/administration/exec-team/ExecTeamPanel.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+
+const ExecTeamPanel = () => {
+  return (
+    <table className='border-separate border-spacing-4'>
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Position</th>
+          <th>Email</th>
+          <th>Contact for</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>John Doe</td>
+          <td>President</td>
+          <td>johndoe@mcmaster.ca</td>
+          <td>General Inquiries</td>
+        </tr>
+        <tr>
+          <td>Jane Doe</td>
+          <td>Vice President</td>
+          <td>janedoe@mcmaster.ca </td>
+          <td>General Inquiries</td>
+        </tr>
+      </tbody>
+    </table>
+  );
+};
+
+export default ExecTeamPanel;

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import Avatar from '@mui/material/Avatar';
 import * as React from 'react';
 import { FaRightFromBracket } from 'react-icons/fa6';
 import { GiHamburgerMenu } from 'react-icons/gi';
@@ -11,39 +10,9 @@ import { cn } from '@/lib/utils';
 import IconButton from '@/components/buttons/IconButton';
 import { MESLogo } from '@/components/layout/navbar/MESLogo';
 
-import { sidebarItems } from './sidebarItems';
+import SidebarProps from '@/types/SidebarProps';
 
-type ClubProfileProps = {
-  open: boolean;
-};
-
-const ClubProfile = ({ open }: ClubProfileProps) => {
-  const height = open ? 100 : 50;
-  const width = open ? 100 : 50;
-  return (
-    <div className='flex flex-col items-center justify-center text-nowrap min-h-40'>
-      <div className='flex min-h-28'>
-        <Avatar
-          sx={{ height: height, width: width }}
-          className='transition-all m-auto'
-        >
-          MES
-        </Avatar>
-      </div>
-
-      <span
-        className={cn([
-          'flex justify-center mt-3 overflow-hidden transition-all',
-          open ? 'w-full h-6' : 'w-0 h-0',
-        ])}
-      >
-        Team name
-      </span>
-    </div>
-  );
-};
-
-const Sidebar = () => {
+const Sidebar = (sidebarProps: SidebarProps) => {
   const [open, setOpen] = React.useState(false);
   const iconSize = 30;
   const iconColor = 'gray';
@@ -69,9 +38,9 @@ const Sidebar = () => {
           onClick={() => setOpen(!open)}
           icon={open ? IoIosArrowBack : GiHamburgerMenu}
         />
-        <ClubProfile open={open} />
+        <sidebarProps.profile open={open} {...sidebarProps.profileProps} />
         <div className='flex-col mt-4'>
-          {sidebarItems.map((item) => (
+          {sidebarProps.items.map((item) => (
             <div
               key={item.name}
               className='flex flex-row items-center text-nowrap mx-8 my-3'

--- a/src/components/layout/clubs-user-dashboard/ClubUserDashboardLayout.tsx
+++ b/src/components/layout/clubs-user-dashboard/ClubUserDashboardLayout.tsx
@@ -6,12 +6,14 @@ import TaskBanner from '@/components/layout/clubs-user-dashboard/TaskBanner';
 import ClubsSidebarItems from '@/constant/clubs-dashboard/ClubsSidebarItems';
 
 type dashboardLayoutProps = {
+  showTask?: boolean;
   pageName?: string;
-  children: React.ReactNode;
+  children?: React.ReactNode;
 };
 
 const ClubUserDashboardLayout = ({
   pageName = 'Main Dashboard',
+  showTask = false,
   children,
 }: dashboardLayoutProps) => {
   return (
@@ -19,8 +21,10 @@ const ClubUserDashboardLayout = ({
       <ClubsSidebar items={ClubsSidebarItems} clubName='Team Name' />
       <div className='flex flex-col w-full p-12'>
         <h1>{pageName}</h1>
-        <TaskBanner />
-        <div className='w-full overflow-hidden'>{children}</div>
+        {showTask && <TaskBanner />}
+        <div className='flex flex-col basis-full w-full overflow-hidden mt-5'>
+          {children}
+        </div>
       </div>
     </div>
   );

--- a/src/components/layout/clubs-user-dashboard/ClubUserDashboardLayout.tsx
+++ b/src/components/layout/clubs-user-dashboard/ClubUserDashboardLayout.tsx
@@ -1,7 +1,9 @@
 import * as React from 'react';
 
-import Sidebar from './Sidebar';
-import TaskBanner from './TaskBanner';
+import { ClubsSidebar } from '@/components/layout/clubs-user-dashboard/ClubsSidebar';
+import TaskBanner from '@/components/layout/clubs-user-dashboard/TaskBanner';
+
+import ClubsSidebarItems from '@/constant/clubs-dashboard/ClubsSidebarItems';
 
 type dashboardLayoutProps = {
   pageName?: string;
@@ -14,7 +16,7 @@ const ClubUserDashboardLayout = ({
 }: dashboardLayoutProps) => {
   return (
     <div className='flex h-screen w-screen'>
-      <Sidebar />
+      <ClubsSidebar items={ClubsSidebarItems} clubName='Team Name' />
       <div className='flex flex-col w-full p-12'>
         <h1>{pageName}</h1>
         <TaskBanner />

--- a/src/components/layout/clubs-user-dashboard/ClubsSidebar.tsx
+++ b/src/components/layout/clubs-user-dashboard/ClubsSidebar.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import Avatar from '@mui/material/Avatar';
+
+import { cn } from '@/lib/utils';
+
+import Sidebar from '@/components/layout/Sidebar';
+
+import { ClubsSidebarProps } from '@/types/clubs-dashboard/ClubsSidebarProps';
+import { sidebarProfileProps } from '@/types/SidebarProps';
+
+export const ClubProfile = ({ open, name }: sidebarProfileProps) => {
+  const height = open ? 100 : 50;
+  const width = open ? 100 : 50;
+  return (
+    <div className='flex flex-col items-center justify-center text-nowrap min-h-40'>
+      <div className='flex min-h-28'>
+        <Avatar
+          sx={{ height: height, width: width }}
+          className='transition-all m-auto'
+        >
+          MES
+        </Avatar>
+      </div>
+
+      <span
+        className={cn([
+          'flex justify-center mt-3 overflow-hidden transition-all',
+          open ? 'w-full h-6' : 'w-0 h-0',
+        ])}
+      >
+        {name}
+      </span>
+    </div>
+  );
+};
+
+export const ClubsSidebar = ({ items, clubName }: ClubsSidebarProps) => {
+  return (
+    <Sidebar
+      items={items}
+      profile={ClubProfile}
+      profileProps={{ name: clubName }}
+    />
+  );
+};

--- a/src/components/layout/clubs-user-dashboard/TaskBanner.tsx
+++ b/src/components/layout/clubs-user-dashboard/TaskBanner.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 const TaskBanner = () => {
   return (
-    <div className='flex shrink-0 relative items-center px-7 mt-5 mb-10 h-14 bg-white border-3 rounded-2xl border-primary-800 w-auto text-xl text-black'>
+    <div className='flex shrink-0 relative items-center px-7 mt-5 h-14 bg-white border-3 rounded-2xl border-primary-800 w-auto text-xl text-black'>
       <span>This is a task banner that reminds clubs to do something.</span>
       <div className='absolute top-2 right-2 w-3 h-3 bg-primary-800 rounded-full'></div>
     </div>

--- a/src/components/layout/tab-panel/Tab.tsx
+++ b/src/components/layout/tab-panel/Tab.tsx
@@ -1,0 +1,21 @@
+import { Tab as MuiTab, TabProps } from '@mui/material';
+import React from 'react';
+
+const Tab: React.FC<TabProps> = (props) => {
+  return (
+    <MuiTab
+      sx={{
+        '&.Mui-selected': {
+          color: 'var(--color-primary-800)',
+        },
+        '&:hover': {
+          color: 'var(--color-primary-800)',
+        },
+      }}
+      disableRipple
+      {...props}
+    />
+  );
+};
+
+export default Tab;

--- a/src/components/layout/tab-panel/TabList.tsx
+++ b/src/components/layout/tab-panel/TabList.tsx
@@ -1,0 +1,21 @@
+import { TabList as MuiTabList, TabListProps } from '@mui/lab';
+import React from 'react';
+
+const TabList: React.FC<TabListProps> = (props) => {
+  return (
+    <MuiTabList
+      TabIndicatorProps={{
+        style: { backgroundColor: 'rgb(var(--tw-color-primary-800))' },
+      }}
+      sx={{
+        //this isnt working for some reason
+        '&.MuiTabs-flexContainer': {
+          justifyContent: 'space-around',
+        },
+      }}
+      {...props}
+    />
+  );
+};
+
+export default TabList;

--- a/src/components/layout/tab-panel/TabPanel.tsx
+++ b/src/components/layout/tab-panel/TabPanel.tsx
@@ -1,0 +1,18 @@
+import { TabPanel as MuiTabPanel, TabPanelProps } from '@mui/lab';
+import React from 'react';
+
+const TabPanel: React.FC<TabPanelProps> = (props) => {
+  return (
+    <MuiTabPanel
+      sx={{
+        flexBasis: '100%',
+        overflow: 'hidden',
+        display: 'flex',
+        padding: 0,
+      }}
+      {...props}
+    />
+  );
+};
+
+export default TabPanel;

--- a/src/components/layout/tab-panel/TabPanel.tsx
+++ b/src/components/layout/tab-panel/TabPanel.tsx
@@ -2,17 +2,13 @@ import { TabPanel as MuiTabPanel, TabPanelProps } from '@mui/lab';
 import React from 'react';
 
 const TabPanel: React.FC<TabPanelProps> = (props) => {
-  return (
-    <MuiTabPanel
-      sx={{
-        flexBasis: '100%',
-        overflow: 'hidden',
-        display: 'flex',
-        padding: 0,
-      }}
-      {...props}
-    />
-  );
+  const sx = {
+    overflow: 'hidden',
+    display: 'flex',
+    padding: 0,
+    ...props.sx,
+  };
+  return <MuiTabPanel {...props} sx={sx} />;
 };
 
 export default TabPanel;

--- a/src/constant/clubs-dashboard/AdminSidebarItems.ts
+++ b/src/constant/clubs-dashboard/AdminSidebarItems.ts
@@ -1,0 +1,51 @@
+'use client';
+import { FaHouse } from 'react-icons/fa6';
+import { FaScroll } from 'react-icons/fa6';
+import { FaSquareCheck } from 'react-icons/fa6';
+import { FaDoorOpen } from 'react-icons/fa6';
+import { FaNewspaper } from 'react-icons/fa6';
+import { FaCalendarDays } from 'react-icons/fa6';
+import { FaPeopleGroup } from 'react-icons/fa6';
+
+import SidebarItem from '@/types/clubs-dashboard/SidebarItemType';
+
+const url = '/clubs-portal/admin';
+const sidebarItems: SidebarItem[] = [
+  {
+    name: 'Admin Dashboard',
+    icon: FaHouse,
+    link: `${url}`,
+  },
+  {
+    name: 'Documentation',
+    icon: FaScroll,
+    link: `${url}/expenses`,
+  },
+  {
+    name: 'Add/Remove Club',
+    icon: FaSquareCheck,
+    link: `${url}/events-approval`,
+  },
+  {
+    name: 'View all Clubs',
+    icon: FaPeopleGroup,
+    link: `${url}/room-booking`,
+  },
+  {
+    name: 'View all Events',
+    icon: FaCalendarDays,
+    link: `${url}/rentals-and-services`,
+  },
+  {
+    name: 'UHS Forms',
+    icon: FaNewspaper,
+    link: `${url}/help`,
+  },
+  {
+    name: 'Room Bookings',
+    icon: FaDoorOpen,
+    link: `${url}/club-administration`,
+  },
+];
+
+export default sidebarItems;

--- a/src/constant/clubs-dashboard/ClubsSidebarItems.ts
+++ b/src/constant/clubs-dashboard/ClubsSidebarItems.ts
@@ -44,7 +44,7 @@ const sidebarItems: SidebarItem[] = [
   {
     name: 'Club Administration',
     icon: FaUserLarge,
-    link: `${url}/club-administration`,
+    link: `${url}/administration`,
   },
 ];
 

--- a/src/constant/clubs-dashboard/ClubsSidebarItems.ts
+++ b/src/constant/clubs-dashboard/ClubsSidebarItems.ts
@@ -1,3 +1,4 @@
+'use client';
 import { FaHouse } from 'react-icons/fa6';
 import { FaMoneyBill } from 'react-icons/fa6';
 import { FaSquareCheck } from 'react-icons/fa6';
@@ -5,9 +6,11 @@ import { FaDoorOpen } from 'react-icons/fa6';
 import { FaScrewdriverWrench } from 'react-icons/fa6';
 import { FaCircleQuestion } from 'react-icons/fa6';
 import { FaUserLarge } from 'react-icons/fa6';
-import { IconType } from 'react-icons/lib';
+
+import SidebarItem from '@/types/clubs-dashboard/SidebarItemType';
+
 const url = '/clubs-portal';
-export const sidebarItems: SidebarItem[] = [
+const sidebarItems: SidebarItem[] = [
   {
     name: 'Main Dashboard',
     icon: FaHouse,
@@ -45,8 +48,4 @@ export const sidebarItems: SidebarItem[] = [
   },
 ];
 
-type SidebarItem = {
-  name: string;
-  icon: IconType;
-  link: string;
-};
+export default sidebarItems;

--- a/src/lib/context/ClubProfileContext.tsx
+++ b/src/lib/context/ClubProfileContext.tsx
@@ -10,12 +10,12 @@ import { SocialMedia, TClubProfile } from '@/types/clubProfile';
 export type TClubProfileContext = {
   profileData: TClubProfile;
   clubId: string;
-  setClubId: React.Dispatch<React.SetStateAction<string>>;
   setProfileData: React.Dispatch<React.SetStateAction<TClubProfile>>;
   handleChange: (fields: Partial<TClubProfile>) => void;
   handleSave: () => Promise<string>;
   hasChanges: boolean;
-  status: string;
+  isLoading: boolean;
+  isError: boolean;
 };
 type Props = {
   children: React.ReactNode;
@@ -25,8 +25,12 @@ export const ClubProfileContext = createContext<
 >(undefined);
 
 export const ClubProfileProvider = ({ children }: Props) => {
-  const [clubId, setClubId] = React.useState<string>('1');
-  const { data: persistedProfile, status } = useFetchClubProfile(clubId);
+  const clubId = '1';
+  const {
+    data: persistedProfile,
+    isLoading: queryLoading,
+    isError,
+  } = useFetchClubProfile(clubId);
   const [profileData, setProfileData] = React.useState<TClubProfile>({
     _id: '',
     name: '',
@@ -36,6 +40,7 @@ export const ClubProfileProvider = ({ children }: Props) => {
     description: '',
     socials: {} as Record<SocialMedia, string>,
   });
+  const [isLoading, setIsLoading] = React.useState(true);
   const [profileUpdates, setProfileUpdates] = React.useState<
     Partial<TClubProfile>
   >({});
@@ -43,10 +48,11 @@ export const ClubProfileProvider = ({ children }: Props) => {
   const hasChanges = Object.keys(profileUpdates).length > 0;
 
   useEffect(() => {
-    if (persistedProfile) {
+    if (persistedProfile && !queryLoading) {
       setProfileData(persistedProfile);
+      setIsLoading(false);
     }
-  }, [persistedProfile]);
+  }, [persistedProfile, queryLoading]);
 
   const handleChange = (fields: Partial<TClubProfile>) => {
     setProfileData((prevData) => ({
@@ -80,12 +86,12 @@ export const ClubProfileProvider = ({ children }: Props) => {
       value={{
         profileData,
         clubId,
-        setClubId,
         setProfileData,
         handleChange,
         handleSave,
         hasChanges,
-        status,
+        isLoading,
+        isError,
       }}
     >
       {children}

--- a/src/lib/context/ClubProfileContext.tsx
+++ b/src/lib/context/ClubProfileContext.tsx
@@ -1,0 +1,74 @@
+import React, { createContext } from 'react';
+
+import { useFetchClubProfile } from '@/lib/hooks/clubProfileHooks';
+
+import { SocialMedia, TClubProfile } from '@/types/clubProfile';
+
+export type TClubProfileContext = {
+  profileData: TClubProfile;
+  setProfileData: React.Dispatch<React.SetStateAction<TClubProfile>>;
+  handleChange: (field: string, value: string) => void;
+  handleSocialChange: (name: SocialMedia, value: string) => void;
+  handleSocialDelete: (name: SocialMedia) => void;
+};
+type Props = {
+  children: React.ReactNode;
+};
+export const ClubProfileContext = createContext<
+  TClubProfileContext | undefined
+>(undefined);
+
+export const ClubProfileProvider = ({ children }: Props) => {
+  const [clubId, _setClubId] = React.useState<string>('1');
+  const { data: currentProfile } = useFetchClubProfile(clubId);
+  const [profileData, setProfileData] = React.useState<TClubProfile>(
+    currentProfile || {
+      _id: '',
+      name: '',
+      clubId: '',
+      profilePicture: '',
+      email: '',
+      description: '',
+      socials: {} as Record<SocialMedia, string>,
+    },
+  );
+
+  const handleChange = (field: string, value: string) => {
+    setProfileData((prevData) => ({
+      ...prevData,
+      [field]: value,
+    }));
+  };
+
+  const handleSocialChange = (name: SocialMedia, value: string) => {
+    const updatedSocialMedia = profileData.socials;
+    updatedSocialMedia[name] = value;
+    setProfileData((prevData) => ({
+      ...prevData,
+      socials: updatedSocialMedia,
+    }));
+  };
+
+  const handleSocialDelete = (name: SocialMedia) => {
+    const updatedSocialMedia = profileData.socials;
+    delete updatedSocialMedia[name];
+    setProfileData((prevData) => ({
+      ...prevData,
+      socials: updatedSocialMedia,
+    }));
+  };
+
+  return (
+    <ClubProfileContext.Provider
+      value={{
+        profileData,
+        setProfileData,
+        handleChange,
+        handleSocialChange,
+        handleSocialDelete,
+      }}
+    >
+      {children}
+    </ClubProfileContext.Provider>
+  );
+};

--- a/src/lib/context/ClubProfileContext.tsx
+++ b/src/lib/context/ClubProfileContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext } from 'react';
+import React, { createContext, useContext, useEffect } from 'react';
 
 import { useFetchClubProfile } from '@/lib/hooks/clubProfileHooks';
 
@@ -6,10 +6,14 @@ import { SocialMedia, TClubProfile } from '@/types/clubProfile';
 
 export type TClubProfileContext = {
   profileData: TClubProfile;
+  clubId: string;
+  setClubId: React.Dispatch<React.SetStateAction<string>>;
   setProfileData: React.Dispatch<React.SetStateAction<TClubProfile>>;
   handleChange: (field: string, value: string) => void;
   handleSocialChange: (name: SocialMedia, value: string) => void;
   handleSocialDelete: (name: SocialMedia) => void;
+  handleSave: () => void;
+  status: string;
 };
 type Props = {
   children: React.ReactNode;
@@ -19,8 +23,8 @@ export const ClubProfileContext = createContext<
 >(undefined);
 
 export const ClubProfileProvider = ({ children }: Props) => {
-  const [clubId, _setClubId] = React.useState<string>('1');
-  const { data: currentProfile } = useFetchClubProfile(clubId);
+  const [clubId, setClubId] = React.useState<string>('1');
+  const { data: currentProfile, status } = useFetchClubProfile(clubId);
   const [profileData, setProfileData] = React.useState<TClubProfile>(
     currentProfile || {
       _id: '',
@@ -33,6 +37,12 @@ export const ClubProfileProvider = ({ children }: Props) => {
     },
   );
 
+  useEffect(() => {
+    if (currentProfile) {
+      setProfileData(currentProfile);
+    }
+  }, [currentProfile]);
+
   const handleChange = (field: string, value: string) => {
     setProfileData((prevData) => ({
       ...prevData,
@@ -41,34 +51,55 @@ export const ClubProfileProvider = ({ children }: Props) => {
   };
 
   const handleSocialChange = (name: SocialMedia, value: string) => {
-    const updatedSocialMedia = profileData.socials;
-    updatedSocialMedia[name] = value;
     setProfileData((prevData) => ({
       ...prevData,
-      socials: updatedSocialMedia,
+      socials: {
+        ...prevData.socials,
+        [name]: value,
+      },
     }));
   };
 
   const handleSocialDelete = (name: SocialMedia) => {
-    const updatedSocialMedia = profileData.socials;
-    delete updatedSocialMedia[name];
-    setProfileData((prevData) => ({
-      ...prevData,
-      socials: updatedSocialMedia,
-    }));
+    setProfileData((prevData) => {
+      const updatedSocialMedia = { ...prevData.socials };
+      delete updatedSocialMedia[name];
+      return {
+        ...prevData,
+        socials: updatedSocialMedia,
+      };
+    });
+  };
+
+  const handleSave = () => {
+    return true;
   };
 
   return (
     <ClubProfileContext.Provider
       value={{
         profileData,
+        clubId,
+        setClubId: setClubId,
         setProfileData,
         handleChange,
         handleSocialChange,
         handleSocialDelete,
+        handleSave,
+        status,
       }}
     >
       {children}
     </ClubProfileContext.Provider>
   );
+};
+
+export const useClubProfileContext = () => {
+  const context = useContext(ClubProfileContext);
+  if (context === undefined) {
+    throw new Error(
+      'useClubProfileContext must be used within a ClubProfileProvider',
+    );
+  }
+  return context;
 };

--- a/src/lib/context/ClubProfileContext.tsx
+++ b/src/lib/context/ClubProfileContext.tsx
@@ -13,7 +13,7 @@ export type TClubProfileContext = {
   setClubId: React.Dispatch<React.SetStateAction<string>>;
   setProfileData: React.Dispatch<React.SetStateAction<TClubProfile>>;
   handleChange: (fields: Partial<TClubProfile>) => void;
-  handleSave: () => void;
+  handleSave: () => Promise<string>;
   hasChanges: boolean;
   status: string;
 };

--- a/src/lib/db/clubProfileDb.ts
+++ b/src/lib/db/clubProfileDb.ts
@@ -40,14 +40,13 @@ export const getProfileByClubId = async (
 
 export const updateProfileByClubId = async (
   clubId: string,
-  updatedProfile: TClubProfile,
+  profileUpdates: Partial<TClubProfile>,
 ): Promise<TClubProfile | null> => {
   try {
     const profileCollection = await getClubProfileCollection();
 
-    const { _id, ...profileUpdates } = updatedProfile;
     const result = await profileCollection.findOneAndUpdate(
-      { club_id: clubId },
+      { clubId: clubId },
       { $set: profileUpdates },
       { returnDocument: 'after' },
     );

--- a/src/lib/db/clubProfileDb.ts
+++ b/src/lib/db/clubProfileDb.ts
@@ -17,7 +17,7 @@ const getClubProfileCollection = async () => {
   }
 };
 
-export const getProfileByClubId = async (
+export const getProfileByClubIdDb = async (
   clubId: string,
 ): Promise<TClubProfile | null> => {
   try {
@@ -38,7 +38,7 @@ export const getProfileByClubId = async (
   }
 };
 
-export const updateProfileByClubId = async (
+export const updateProfileByClubIdDb = async (
   clubId: string,
   profileUpdates: Partial<TClubProfile>,
 ): Promise<TClubProfile | null> => {

--- a/src/lib/db/clubProfileDb.ts
+++ b/src/lib/db/clubProfileDb.ts
@@ -1,0 +1,63 @@
+import { WithId } from 'mongodb';
+
+import clientPromise from '@/lib/db';
+
+import { TClubProfile } from '@/types/clubProfile';
+
+const getClubProfileCollection = async () => {
+  try {
+    const client = await clientPromise;
+
+    const db = client.db();
+    const profileCollection = db.collection<TClubProfile>('club_profiles');
+
+    return profileCollection;
+  } catch (error) {
+    throw new Error('Database connection error');
+  }
+};
+
+export const getProfileByClubId = async (
+  clubId: string,
+): Promise<TClubProfile | null> => {
+  try {
+    const profileCollection = await getClubProfileCollection();
+
+    const profile: WithId<TClubProfile> | null =
+      await profileCollection.findOne({
+        clubId: clubId,
+      });
+
+    if (!profile) {
+      return null;
+    }
+
+    return profile;
+  } catch (error) {
+    throw new Error('Database error');
+  }
+};
+
+export const updateProfileByClubId = async (
+  clubId: string,
+  updatedProfile: TClubProfile,
+): Promise<TClubProfile | null> => {
+  try {
+    const profileCollection = await getClubProfileCollection();
+
+    const { _id, ...profileUpdates } = updatedProfile;
+    const result = await profileCollection.findOneAndUpdate(
+      { club_id: clubId },
+      { $set: profileUpdates },
+      { returnDocument: 'after' },
+    );
+
+    if (!result) {
+      return null;
+    }
+
+    return result;
+  } catch (error) {
+    throw new Error('Database error: ' + error);
+  }
+};

--- a/src/lib/fetchers/clubProfileFetchers.ts
+++ b/src/lib/fetchers/clubProfileFetchers.ts
@@ -1,0 +1,31 @@
+import { TClubProfile } from '@/types/clubProfile';
+
+export async function fetchClubProfile(clubId: string): Promise<TClubProfile> {
+  const response = await fetch('/api/clubs/get-profile', {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+      'Club-ID': clubId,
+    },
+  });
+
+  const result = await response.json();
+
+  return result.data;
+}
+
+export async function updateClubProfile(
+  profileUpdates: Partial<TClubProfile>,
+): Promise<Partial<TClubProfile>> {
+  const response = await fetch('/api/clubs/update-profile', {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(profileUpdates),
+  });
+
+  const result = await response.json();
+
+  return result.data;
+}

--- a/src/lib/hooks/clubProfileHooks.ts
+++ b/src/lib/hooks/clubProfileHooks.ts
@@ -1,11 +1,17 @@
-import { useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery } from '@tanstack/react-query';
 
 import { TClubProfile } from '@/types/clubProfile';
 
 export const useFetchClubProfile = (clubId: string) => {
   return useQuery<TClubProfile, Error>({
-    queryKey: ['clubProfile', clubId],
+    queryKey: ['clubProfile'],
     queryFn: async () => fetchClubProfile(clubId),
+  });
+};
+
+export const useUpdateClubProfile = () => {
+  return useMutation<Partial<TClubProfile>, Error, Partial<TClubProfile>>({
+    mutationFn: updateClubProfile,
   });
 };
 
@@ -16,6 +22,22 @@ async function fetchClubProfile(clubId: string): Promise<TClubProfile> {
       'Content-Type': 'application/json',
       'Club-ID': clubId,
     },
+  });
+
+  const result = await response.json();
+
+  return result.data;
+}
+
+async function updateClubProfile(
+  profileUpdates: Partial<TClubProfile>,
+): Promise<Partial<TClubProfile>> {
+  const response = await fetch('/api/clubs/update-profile', {
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(profileUpdates),
   });
 
   const result = await response.json();

--- a/src/lib/hooks/clubProfileHooks.ts
+++ b/src/lib/hooks/clubProfileHooks.ts
@@ -1,0 +1,24 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { TClubProfile } from '@/types/clubProfile';
+
+export const useFetchClubProfile = (clubId: string) => {
+  return useQuery<TClubProfile, Error>({
+    queryKey: ['clubProfile', clubId],
+    queryFn: async () => fetchClubProfile(clubId),
+  });
+};
+
+async function fetchClubProfile(clubId: string): Promise<TClubProfile> {
+  const response = await fetch('/api/clubs/get-profile', {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+      'Club-ID': clubId,
+    },
+  });
+
+  const result = await response.json();
+
+  return result.data;
+}

--- a/src/lib/hooks/clubProfileHooks.ts
+++ b/src/lib/hooks/clubProfileHooks.ts
@@ -1,5 +1,10 @@
 import { useMutation, useQuery } from '@tanstack/react-query';
 
+import {
+  fetchClubProfile,
+  updateClubProfile,
+} from '@/lib/fetchers/clubProfileFetchers';
+
 import { TClubProfile } from '@/types/clubProfile';
 
 export const useFetchClubProfile = (clubId: string) => {
@@ -14,33 +19,3 @@ export const useUpdateClubProfile = () => {
     mutationFn: updateClubProfile,
   });
 };
-
-async function fetchClubProfile(clubId: string): Promise<TClubProfile> {
-  const response = await fetch('/api/clubs/get-profile', {
-    method: 'GET',
-    headers: {
-      'Content-Type': 'application/json',
-      'Club-ID': clubId,
-    },
-  });
-
-  const result = await response.json();
-
-  return result.data;
-}
-
-async function updateClubProfile(
-  profileUpdates: Partial<TClubProfile>,
-): Promise<Partial<TClubProfile>> {
-  const response = await fetch('/api/clubs/update-profile', {
-    method: 'PATCH',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify(profileUpdates),
-  });
-
-  const result = await response.json();
-
-  return result.data;
-}

--- a/src/lib/services/clubProfileServices.ts
+++ b/src/lib/services/clubProfileServices.ts
@@ -1,0 +1,31 @@
+import {
+  getProfileByClubIdDb,
+  updateProfileByClubIdDb,
+} from '@/lib/db/clubProfileDb';
+
+import { TClubProfile } from '@/types/clubProfile';
+
+export const getProfileByClubIdService = async (clubId: string) => {
+  try {
+    const profile = await getProfileByClubIdDb(clubId);
+    return profile;
+  } catch (error) {
+    /* eslint-disable no-console */
+    console.error('Error in club profile services:', error);
+    return null;
+  }
+};
+
+export const updateProfileByClubIdService = async (
+  clubId: string,
+  profileUpdates: Partial<TClubProfile>,
+) => {
+  try {
+    const result = await updateProfileByClubIdDb(clubId, profileUpdates);
+    return result;
+  } catch (error) {
+    /* eslint-disable no-console */
+    console.error('Error in club profile services:', error);
+    return null;
+  }
+};

--- a/src/types/SidebarProps.ts
+++ b/src/types/SidebarProps.ts
@@ -1,0 +1,14 @@
+import SidebarItem from '@/types/clubs-dashboard/SidebarItemType';
+
+export interface sidebarProfileProps {
+  open: boolean;
+  name: string;
+}
+
+type SidebarProps = {
+  items: SidebarItem[];
+  profile: React.ComponentType<sidebarProfileProps>;
+  profileProps: Omit<sidebarProfileProps, 'open'>; // good way to let other things pass in all props for the profile except for open.
+};
+
+export default SidebarProps;

--- a/src/types/clubProfile.ts
+++ b/src/types/clubProfile.ts
@@ -1,0 +1,20 @@
+export type ClubProfile = {
+  id: string;
+  name: string;
+  email: string;
+  description: string;
+  socials: Record<SocialMedia, string>;
+};
+
+export type SocialMedia =
+  | 'website'
+  | 'instagram'
+  | 'facebook'
+  | 'linkedin'
+  | 'twitter'
+  | 'youtube'
+  | 'linktree'
+  | 'github'
+  | 'tiktok'
+  | 'discord'
+  | 'mailingList';

--- a/src/types/clubProfile.ts
+++ b/src/types/clubProfile.ts
@@ -1,8 +1,12 @@
-export type ClubProfile = {
-  id: string;
+import { ObjectId } from 'mongodb';
+
+export type TClubProfile = {
+  _id: string | ObjectId;
+  clubId: string;
   name: string;
   email: string;
-  description: string;
+  description?: string;
+  profilePicture?: string;
   socials: Record<SocialMedia, string>;
 };
 

--- a/src/types/clubs-dashboard/ClubsSidebarProps.ts
+++ b/src/types/clubs-dashboard/ClubsSidebarProps.ts
@@ -1,0 +1,6 @@
+import SidebarItem from '@/types/clubs-dashboard/SidebarItemType';
+
+export type ClubsSidebarProps = {
+  items: SidebarItem[];
+  clubName: string;
+};

--- a/src/types/clubs-dashboard/SidebarItemType.ts
+++ b/src/types/clubs-dashboard/SidebarItemType.ts
@@ -1,0 +1,9 @@
+import { IconType } from 'react-icons/lib';
+
+type SidebarItem = {
+  name: string;
+  icon: IconType;
+  link: string;
+};
+
+export default SidebarItem;


### PR DESCRIPTION
# Description & Technical Solution

This PR adds the club administration page and the club profile tab.

Club profiles are fetched from and persisted in the database in a new collection `club_profiles`. They are fetched and updated based on the `clubId`, and I assumed there would be some global context to get that in the future and replace the placeholder, which is `'1'` for now.

Example schema:
```
{
  "_id": {
    "$oid": "66cf95adab0f2ae8643eb0d0"
  },
  "clubId": "1",
  "name": "MES",
  "email": "mes@mcmaster.ca",
  "description": "This is a test. This is a new change",
  "socials": {
    "youtube": "youtube.com/mes",
    "facebook": "facebook.com/mes"
  }
}
```
I created a new folder for fetchers in `lib/fetchers`

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] Already rebased against main branch.

# Screenshots

Provide screenshots or videos of the changes made if any.
![image](https://github.com/user-attachments/assets/f229724a-aab0-4678-9e2a-af565319201e)

# Issue number
Closes #151
