### PR TITLE
fix: add signin gate back to auth routes, get it working with profile…

### DIFF
--- a/src/app/auth/error/page.tsx
+++ b/src/app/auth/error/page.tsx
@@ -2,13 +2,18 @@ import ServerSignInGate from '@slices/auth/components/ServerSignInGate';
 import React from 'react';
 
 import { ErrorPage } from '@/app/auth/error/ErrorPage';
+import SignInGatePage from '@/slices/auth/components/SignInGatePage';
 
 const requireSignIn = false;
 const href = '/';
 
 const Error = async () => {
   await ServerSignInGate({ requireSignIn: requireSignIn, href: href });
-  return <ErrorPage />;
+  return (
+    <SignInGatePage requireSignIn={requireSignIn} href={href}>
+      <ErrorPage />
+    </SignInGatePage>
+  );
 };
 
 export default Error;

--- a/src/app/auth/sign-in/page.tsx
+++ b/src/app/auth/sign-in/page.tsx
@@ -2,13 +2,18 @@ import ServerSignInGate from '@slices/auth/components/ServerSignInGate';
 import React from 'react';
 
 import { SignInPage } from '@/app/auth/sign-in/signin';
+import SignInGatePage from '@/slices/auth/components/SignInGatePage';
 
 const requireSignIn = false;
 const href = '/hatch-booking/new-booking';
 
 const SignIn = async () => {
   await ServerSignInGate({ requireSignIn: requireSignIn, href: href });
-  return <SignInPage />;
+  return (
+    <SignInGatePage requireSignIn={requireSignIn} href={href}>
+      <SignInPage />
+    </SignInGatePage>
+  );
 };
 
 export default SignIn;

--- a/src/slices/auth/context/SessionContext.tsx
+++ b/src/slices/auth/context/SessionContext.tsx
@@ -21,7 +21,7 @@ import { useFetchProfileByEmailHook } from '@/slices/auth/hooks/profileHooks';
 type TSessionContext = {
   profile?: TProfile;
   isAdmin: boolean;
-  isFetched: boolean;
+  profileIsLoaded: boolean;
 };
 
 export const SessionContext = createContext<TSessionContext | undefined>(
@@ -39,10 +39,15 @@ type Props = {
  */
 export const SessionProvider = ({ children }: Props) => {
   const [email, setEmail] = useState<string | null>(null);
+  const [profileHookStatus, setProfileHookStatus] = useState<
+    'unknown' | 'disabled' | 'fetching'
+  >('unknown'); // NOTE: Tried using useRef, something about useState making it rerender is needed for it to work though.
 
   useEffect(() => {
     const fetchUserEmail = async () => {
+      setProfileHookStatus('unknown'); // Sets to unknown so if someone signs out, the status is reverted back.
       const fetchedEmail = await getUserEmail();
+      setProfileHookStatus(fetchedEmail ? 'fetching' : 'disabled');
       setEmail(fetchedEmail);
     };
 
@@ -60,7 +65,7 @@ export const SessionProvider = ({ children }: Props) => {
       value={{
         profile: profile,
         isAdmin: isAdmin,
-        isFetched: isFetched,
+        profileIsLoaded: isFetched || profileHookStatus === 'disabled', // Consider it loaded if it is fetched or if it is disabled.
       }}
     >
       {children}


### PR DESCRIPTION

# Description & Technical Solution

Previously, the SignInGatePage was removed from auth sign in and error endpoints because users who were not signed in would be stuck on a continuous loading screen due to their profile never loading (because they weren't signed in). 

Fixed this behaviour to now contain a state variable which determines if the loading is pending or disabled, so that if it is disabled, redirect / rendering logic still applies and the user is either able to be redirected or have the proper page content rendered depending on their logged in status and the logic for that specific page.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] Already rebased against main branch.

# Screenshots

N/A

# Issue number

Closes #296 
