### PR TITLE
fix: center booking page contents on big screens

### DIFF
--- a/src/app/hatch-booking/layout.tsx
+++ b/src/app/hatch-booking/layout.tsx
@@ -29,7 +29,7 @@ export default function NewBookingSystemLayout({
             <SessionProvider>
               <TimePickerProvider>
                 <div className='flex h-[200px] max-h-[200px] w-full justify-center'>
-                  <div className='flex w-full flex-col gap-2 bg-white p-4 md:px-12'>
+                  <div className='flex w-full flex-col gap-2 bg-white p-4 md:px-12 max-w-[1452px]'>
                     <h1 className='text-xl font-semibold'>
                       Hatch Room Booking
                     </h1>


### PR DESCRIPTION
# Description & Technical Solution

The maximum width of the page contents is 1452px, after that it would cause the contents to be left-aligned on big screens which didn't look good. This simply limits the width to 1452px so that on bigger screens everything is center-aligned.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] Already rebased against main branch.

# Screenshots

![image](https://github.com/user-attachments/assets/7b284315-fbc8-49ad-84d8-20a701b65606)


# Issue number

Closes https://github.com/McMaster-Engineering-Society/MES-Website-App-Router/issues/311
