### PR TITLE
feat: improve view booking modal

### DIFF
--- a/src/slices/hatch/booking-page/components/BookingIndicator.tsx
+++ b/src/slices/hatch/booking-page/components/BookingIndicator.tsx
@@ -21,6 +21,7 @@ import { HatchRoomsData } from '@/constant/hatch-bookings/rooms-data';
 import { useFetchProfileByEmailHook } from '@/slices/auth/hooks/profileHooks';
 import RoomInfoModal from '@/slices/hatch/booking-page/components/RoomInfoModal';
 import { useDeleteBookingHook } from '@/slices/hatch/booking-page/hooks/bookingHooks';
+import { add30Minutes } from '@/slices/hatch/booking-page/utils';
 
 type BookingIndicatorProps = {
   booking: TBooking;
@@ -86,22 +87,23 @@ const BookingIndicator = ({ booking, isAdmin }: BookingIndicatorProps) => {
             {(onClose) => (
               <>
                 <ModalHeader className='flex flex-col gap-1'>
-                  Booking in Room {bookingTooltipContent}
+                  Booking Details
                 </ModalHeader>
                 <ModalBody>
-                  <div className='flex flex-col gap-4'>
-                    <div className=''>
-                      <p className='mb-2'>User Profile</p>
-                      {userProfileIsPending && <p>Loading user profile...</p>}
-                      {userProfileError && <p>Error loading user profile.</p>}
-                      {userProfileData && (
-                        <pre className='text-sm bg-gray-200 p-2 rounded-md overflow-auto'>
-                          {JSON.stringify(userProfileData, null, 2)}
-                        </pre>
-                      )}
-                    </div>
+                  <div className='flex flex-col gap-1'>
+                    <p className=''>Room: {booking.room}</p>
+                    <p className=''>
+                      Start Time: {format(booking.startTime, 'h:mm a')}
+                    </p>
+                    <p className=''>
+                      End Time:{' '}
+                      {format(add30Minutes(booking.endTime), 'h:mm a')}
+                    </p>
+                    <p className=''>
+                      Has Confirmed: {booking.hasConfirmed ? 'Yes' : 'No'}
+                    </p>
                     <p>
-                      Booking created{' '}
+                      Booking Created:{' '}
                       {booking.createdDate
                         ? new Date(booking.createdDate).toLocaleString(
                             'en-US',
@@ -116,6 +118,14 @@ const BookingIndicator = ({ booking, isAdmin }: BookingIndicatorProps) => {
                           )
                         : 'Invalid Date'}
                     </p>
+                    <p className=''>User Profile:</p>
+                    {userProfileIsPending && <p>Loading user profile...</p>}
+                    {userProfileError && <p>Error loading user profile.</p>}
+                    {userProfileData && (
+                      <pre className='text-sm bg-gray-200 p-2 rounded-md overflow-auto'>
+                        {JSON.stringify(userProfileData, null, 2)}
+                      </pre>
+                    )}
                   </div>
                 </ModalBody>
                 <ModalFooter>
@@ -153,13 +163,13 @@ const BookingIndicator = ({ booking, isAdmin }: BookingIndicatorProps) => {
               }}
             >
               {`Cancel Booking ${
-                format(formattedStartTime, 'h:mm a') +
+                format(booking.startTime, 'h:mm a') +
                 ' to ' +
-                format(formattedEndTime, 'h:mm a')
+                format(booking.endTime, 'h:mm a')
               }`}
             </Button>
           )}
-          customDate={formattedStartTime}
+          customDate={booking.startTime}
         />
       )}
     </div>

--- a/src/slices/hatch/booking-page/components/BookingIndicator.tsx
+++ b/src/slices/hatch/booking-page/components/BookingIndicator.tsx
@@ -162,7 +162,11 @@ const BookingIndicator = ({ booking, isAdmin }: BookingIndicatorProps) => {
                 onClose();
               }}
             >
-              Cancel Booking
+              Cancel{' '}
+              {format(booking.startTime, 'h:mm a') +
+                ' to ' +
+                format(add30Minutes(booking.endTime), 'h:mm a')}{' '}
+              Booking
             </Button>
           )}
           customDate={booking.startTime}

--- a/src/slices/hatch/booking-page/components/BookingIndicator.tsx
+++ b/src/slices/hatch/booking-page/components/BookingIndicator.tsx
@@ -162,11 +162,7 @@ const BookingIndicator = ({ booking, isAdmin }: BookingIndicatorProps) => {
                 onClose();
               }}
             >
-              {`Cancel Booking ${
-                format(booking.startTime, 'h:mm a') +
-                ' to ' +
-                format(booking.endTime, 'h:mm a')
-              }`}
+              Cancel Booking
             </Button>
           )}
           customDate={booking.startTime}

--- a/src/slices/hatch/booking-page/components/RoomInfoModal.tsx
+++ b/src/slices/hatch/booking-page/components/RoomInfoModal.tsx
@@ -108,7 +108,7 @@ function RoomInfoModal({
                 </div>
               </div>
             </ModalBody>
-            <ModalFooter className='justify-center'>
+            <ModalFooter className={`${!CustomFooter && 'justify-center'}`}>
               {CustomFooter ? (
                 <CustomFooter onClose={onClose} />
               ) : (

--- a/src/slices/hatch/booking-page/components/RoomInfoModal.tsx
+++ b/src/slices/hatch/booking-page/components/RoomInfoModal.tsx
@@ -108,7 +108,7 @@ function RoomInfoModal({
                 </div>
               </div>
             </ModalBody>
-            <ModalFooter className={`${!CustomFooter && 'justify-center'}`}>
+            <ModalFooter className='justify-center'>
               {CustomFooter ? (
                 <CustomFooter onClose={onClose} />
               ) : (

--- a/src/slices/hatch/booking-page/components/RoomInfoModal.tsx
+++ b/src/slices/hatch/booking-page/components/RoomInfoModal.tsx
@@ -22,6 +22,8 @@ type Props = {
   onOpenChange: (isOpen: boolean) => void;
   roomInfo: THatchRoom;
   handleConfirmBookingWithMessage: () => void;
+  CustomFooter?: React.FC<{ onClose: () => void }>;
+  customDate?: Date;
 };
 
 function RoomInfoModal({
@@ -29,6 +31,8 @@ function RoomInfoModal({
   onOpenChange,
   roomInfo,
   handleConfirmBookingWithMessage,
+  CustomFooter,
+  customDate,
 }: Props) {
   // filters out only available resources in the room
   // had to add key as a condition bc eslint was giving me warning :(
@@ -37,6 +41,8 @@ function RoomInfoModal({
     .map(([key]) => key);
   const { startIndex, endIndex, timeSlotIndexToTimeISODate } =
     useTimePickerContext();
+  const date = customDate || timeSlotIndexToTimeISODate(startIndex);
+
   return (
     <Modal
       size='sm'
@@ -63,13 +69,9 @@ function RoomInfoModal({
               </p>
               <div className='flex justify-between mx-2'>
                 <div className='w-fit h-auto border border-black text-3xl px-3 mr-4 flex flex-col text-center items-center justify-center rounded-xl'>
-                  {startIndex &&
-                    endIndex &&
-                    format(timeSlotIndexToTimeISODate(startIndex), 'MMM')}
-                  <p className='text-5xl'>
-                    {format(timeSlotIndexToTimeISODate(startIndex), 'd')}
-                  </p>
-                  {format(timeSlotIndexToTimeISODate(startIndex), 'yyyy')}
+                  {startIndex && endIndex && format(date, 'MMM')}
+                  <p className='text-5xl'>{format(date, 'd')}</p>
+                  {format(date, 'yyyy')}
                 </div>
 
                 <div className='flex justify-between w-fit p-3 bg-gray-200 rounded-xl'>
@@ -107,31 +109,40 @@ function RoomInfoModal({
               </div>
             </ModalBody>
             <ModalFooter className='justify-center'>
-              <Button
-                color='danger'
-                variant='light'
-                onPress={onClose}
-                className='hidden md:block'
-              >
-                Close
-              </Button>
+              {CustomFooter ? (
+                <CustomFooter onClose={onClose} />
+              ) : (
+                <>
+                  <Button
+                    color='danger'
+                    variant='light'
+                    onPress={onClose}
+                    className='hidden md:block'
+                  >
+                    Close
+                  </Button>
 
-              <Button
-                color='warning'
-                onPress={onClose}
-                onClick={handleConfirmBookingWithMessage} //displays room confirmation sonner
-                className='flex-1 bg-[#28a745]'
-              >
-                {startIndex &&
-                  endIndex &&
-                  'Book from ' +
-                    format(timeSlotIndexToTimeISODate(startIndex), 'h:mm a') +
-                    ' to ' +
-                    format(
-                      add30Minutes(timeSlotIndexToTimeISODate(endIndex)),
-                      'h:mm a',
-                    )}
-              </Button>
+                  <Button
+                    color='warning'
+                    onPress={onClose}
+                    onClick={handleConfirmBookingWithMessage} //displays room confirmation sonner
+                    className='flex-1 bg-[#28a745]'
+                  >
+                    {startIndex &&
+                      endIndex &&
+                      'Book from ' +
+                        format(
+                          timeSlotIndexToTimeISODate(startIndex),
+                          'h:mm a',
+                        ) +
+                        ' to ' +
+                        format(
+                          add30Minutes(timeSlotIndexToTimeISODate(endIndex)),
+                          'h:mm a',
+                        )}
+                  </Button>
+                </>
+              )}
             </ModalFooter>
           </>
         )}

--- a/src/slices/hatch/booking-page/components/TimePicker.tsx
+++ b/src/slices/hatch/booking-page/components/TimePicker.tsx
@@ -31,7 +31,6 @@ export default function TimePicker({
 }: TimePickerProps) {
   /**
    * changes when users clicks arrows to change the date range
-   * @todo integrate with date picker arrows
    */
   const {
     userBookings,
@@ -406,12 +405,6 @@ function TimePickerTable({
     e.preventDefault();
     dragOperationRef.current = 'None';
   };
-  /**
-   * if we don't include this, the browser will select text and everything will get messed up
-   */
-  const onMouseDown = (e: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
-    e.preventDefault();
-  };
 
   const TimeIndicators = memo(() => {
     /* time indicators along the side */
@@ -499,7 +492,6 @@ function TimePickerTable({
         <TimeIndicators />
         <div
           className='flex flex-1 flex-col rounded-lg bg-white shadow-lg shadow-black/25'
-          onMouseDown={onMouseDown}
           onMouseUp={onMouseUp}
           onMouseLeave={onMouseLeave}
         >


### PR DESCRIPTION
# Description & Technical Solution

When you click on the little booking indicator, it opens a modal. I added more info and separate modals for the user vs the admin:

- For the user, it shows the room info (I reused the `RoomInfoModal.tsx`)
- For the admin, it shows the room info (room number, start/end time, has confirmed, booking created), and all of the user's information we have in their profile. Currently, it simply formats the user profile object nicely as JSON. I think this is perfectly sufficient as it's just for admins anyways. We don't have to deal with any complicated conditional logic if fields are missing, and any fields that are added will always be shown.

I also removed the onMouseDown preventDefault from the time picker. This is to fix an issue where you couldn't select text in the modal (or anything that's a child of the time picker). This preventDefault previously existed to fix an issue with all the text on the page getting selected just by using the time picker, but this was a much earlier version and it does not seem to be an issue anymore.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] Already rebased against main branch.

# Screenshots

User:

![image](https://github.com/user-attachments/assets/002bf514-eb99-48db-93d1-0a31ad86841e)


Admin:

![image](https://github.com/user-attachments/assets/29586d66-c0b7-4587-81fe-2929eb60ff58)

# Issue number

Closes https://github.com/McMaster-Engineering-Society/MES-Website-App-Router/issues/313
