### PR TITLE
Feature/rebook flow

### DIFF
--- a/src/app/hatch-booking/dashboard/BookingDashboardPage.tsx
+++ b/src/app/hatch-booking/dashboard/BookingDashboardPage.tsx
@@ -40,6 +40,7 @@ const UserDashboard = () => {
   const [displayRoom, setDisplayRoom] = useState<string>('');
   const [displayUserId, setDisplayUserId] = useState<string>('');
   const [displayEmail, setDisplayEmail] = useState<string>('');
+  const [displayId, setDisplayId] = useState<string>('');
 
   // todo: display a set number of past bookings and upcoming bookings? e.g: only show 5 of the past bookings, or have some sort of filtering / pagination in the future?
 
@@ -127,6 +128,7 @@ const UserDashboard = () => {
     room: string,
     userId: string,
     email: string,
+    id: string,
   ) {
     setOpen(true);
     setDisplayStartTime(startTime);
@@ -134,6 +136,7 @@ const UserDashboard = () => {
     setDisplayRoom(room);
     setDisplayUserId(userId);
     setDisplayEmail(email);
+    setDisplayId(id);
   }
 
   return (
@@ -195,6 +198,7 @@ const UserDashboard = () => {
                             booking.room,
                             booking.userId,
                             booking.email,
+                            booking._id?.toString() ?? '',
                           )
                         }
                       ></BookingTimeslot>
@@ -282,6 +286,7 @@ const UserDashboard = () => {
                             booking.room,
                             booking.userId,
                             booking.email,
+                            booking._id?.toString() ?? '',
                           )
                         }
                       ></BookingTimeslot>
@@ -343,6 +348,7 @@ const UserDashboard = () => {
           userRoom={displayRoom}
           userId={displayUserId}
           email={displayEmail}
+          id={displayId}
         ></ExpandModal>
       </section>
     </QueryClientProvider>

--- a/src/app/hatch-booking/dashboard/BookingDashboardPage.tsx
+++ b/src/app/hatch-booking/dashboard/BookingDashboardPage.tsx
@@ -22,7 +22,7 @@ import PageSection from '@/components/PageSection';
 import ProfilePicture from '@/constant/user-dashboard/ProfilePictureSvg';
 import { useSessionContext } from '@/slices/auth/context/SessionContext';
 import { BookingTimeslot } from '@/slices/hatch/booking-page/components/BookingTimeslot';
-import RebookModal from '@/slices/hatch/booking-page/components/modals/RebookModal';
+import ExpandModal from '@/slices/hatch/booking-page/components/modals/ExpandModal';
 import { add30Minutes } from '@/slices/hatch/booking-page/utils';
 
 const queryClient = new QueryClient();
@@ -326,7 +326,7 @@ const UserDashboard = () => {
             Report Issue
           </ButtonLink>
         </div>
-        <RebookModal
+        {/* <RebookModal
           open={open}
           onClose={() => setOpen(false)}
           startTime={displayStartTime}
@@ -334,7 +334,16 @@ const UserDashboard = () => {
           userRoom={displayRoom}
           userId={displayUserId}
           email={displayEmail}
-        ></RebookModal>
+        ></RebookModal> */}
+        <ExpandModal
+          open={open}
+          onClose={() => setOpen(false)}
+          startTime={displayStartTime}
+          endTime={displayEndTime}
+          userRoom={displayRoom}
+          userId={displayUserId}
+          email={displayEmail}
+        ></ExpandModal>
       </section>
     </QueryClientProvider>
   );

--- a/src/app/hatch-booking/dashboard/BookingDashboardPage.tsx
+++ b/src/app/hatch-booking/dashboard/BookingDashboardPage.tsx
@@ -331,15 +331,7 @@ const UserDashboard = () => {
             Report Issue
           </ButtonLink>
         </div>
-        {/* <RebookModal
-          open={open}
-          onClose={() => setOpen(false)}
-          startTime={displayStartTime}
-          endTime={displayEndTime}
-          userRoom={displayRoom}
-          userId={displayUserId}
-          email={displayEmail}
-        ></RebookModal> */}
+
         <ExpandModal
           open={open}
           onClose={() => setOpen(false)}

--- a/src/slices/hatch/booking-page/components/modals/CancelModal.tsx
+++ b/src/slices/hatch/booking-page/components/modals/CancelModal.tsx
@@ -1,9 +1,9 @@
-import { addDays, differenceInMinutes, format, startOfDay } from 'date-fns';
-import { Bookmark } from 'lucide-react';
+import { differenceInMinutes, format, startOfDay } from 'date-fns';
+import { CircleX } from 'lucide-react';
 
 import { useAddRoomBookingHook } from '@/slices/hatch/booking-page/hooks/bookingHooks';
 
-type SameRoomModalProps = {
+type CancelModalProps = {
   open: boolean;
   onClose: () => void;
   startTime: Date;
@@ -23,7 +23,7 @@ export type RoomAvailabilities = {
 
 // eslint-disable-next-line unused-imports/no-unused-vars
 /* eslint no-console: ["error", { allow: ["warn", "error"] }] */
-const SameRoomModal: React.FC<SameRoomModalProps> = ({
+const CancelModal: React.FC<CancelModalProps> = ({
   open,
   startTime,
   endTime,
@@ -43,8 +43,6 @@ const SameRoomModal: React.FC<SameRoomModalProps> = ({
   // const [selectedRoom, setSelectedRoom] = useState<string | null>(null);
 
   const addRoomBooking = useAddRoomBookingHook();
-  const startWeek = addDays(startTime, 7);
-  const endWeek = addDays(endTime, 7);
 
   // const { data: roomAvailabilities, isLoading } = useFetchAvailabilitiesHook(startWeek, endWeek);
 
@@ -139,62 +137,37 @@ const SameRoomModal: React.FC<SameRoomModalProps> = ({
           X
         </button>
         {/* {children} */}
-        <h1 className='text-center mx mb-5'>Same Time Tomorrow</h1>
-
+        <h1 className='text-center mx mb-5'>Confirm Cancellation</h1>
         <div className='flex'>
-          <button className='border-solid border-2 border-green-600 rounded-lg px-5 py-5 m-3 bg-green-100 text-green-600'>
-            <div>
-              <b className='text-lg'>
-                Same time
-                <br />
-                next week:
-                <br />
+          <p className='text-small px-3'>
+            <b> {userRoom}</b>, {format(startTime, 'MMMM do')},{' '}
+            {format(startTime, 'p')} ({getDuration(startTime, endTime)}H):
+          </p>
+          <button
+            className='rounded-full bg-red-50 text-red-700 py-0.1 px-2 border-solid border-1 border-red-700 text-sm'
+            onClick={() => {
+              handleBooking(
+                userId,
+                userRoom,
+                startTime,
+                endTime,
+                false,
+                email,
+                startOfDay(new Date()),
+              );
+            }}
+          >
+            <div className='flex'>
+              <CircleX className='w-4 h-4 text-red-700 pt-1 pr-1' />
+              <b>
+                <i>CANCEL BOOKING</i>
               </b>
-              <i>
-                {format(startWeek.toString(), 'p')} (
-                {getDuration(startWeek, endWeek)}H)
-                <br />
-              </i>
-              <i>
-                {format(startWeek, 'MMMM do')}
-                <br />
-              </i>
             </div>
           </button>
-          <div className='ml-5 py-8'>
-            <div className=''>
-              <h4 className='mt-3'>Confirm Booking:</h4>
-              <p className='text-small mb-1.5'>
-                <b> {userRoom}</b>, {format(startWeek, 'MMMM do')},{' '}
-                {format(startWeek, 'p')} ({getDuration(startWeek, endWeek)}H).
-              </p>
-              <button
-                className='rounded-full bg-red-50 text-red-700 py-0.1 px-2 border-solid border-1 border-red-700 text-sm'
-                onClick={() => {
-                  handleBooking(
-                    userId,
-                    userRoom,
-                    startWeek,
-                    endWeek,
-                    false,
-                    email,
-                    startOfDay(new Date()),
-                  );
-                }}
-              >
-                <div className='flex'>
-                  <Bookmark className='w-4 h-4 text-red-700 pt-1 pr-1' />
-                  <b>
-                    <i>BOOK NOW</i>
-                  </b>
-                </div>
-              </button>
-            </div>
-          </div>
         </div>
       </div>
     </div>
   );
 };
 
-export default SameRoomModal;
+export default CancelModal;

--- a/src/slices/hatch/booking-page/components/modals/CancelModal.tsx
+++ b/src/slices/hatch/booking-page/components/modals/CancelModal.tsx
@@ -1,7 +1,8 @@
-import { differenceInMinutes, format, startOfDay } from 'date-fns';
+import { differenceInMinutes, format } from 'date-fns';
 import { CircleX } from 'lucide-react';
+import { toast } from 'sonner';
 
-import { useAddRoomBookingHook } from '@/slices/hatch/booking-page/hooks/bookingHooks';
+import { useDeleteBookingHook } from '@/slices/hatch/booking-page/hooks/bookingHooks';
 
 type CancelModalProps = {
   open: boolean;
@@ -11,6 +12,7 @@ type CancelModalProps = {
   userId: string;
   userRoom: string;
   email: string;
+  id: string;
 };
 
 export type RoomAvailabilities = {
@@ -28,9 +30,8 @@ const CancelModal: React.FC<CancelModalProps> = ({
   startTime,
   endTime,
   onClose,
-  userId,
   userRoom,
-  email,
+  id,
 }) => {
   // const [availabilities, setAvailabilities] = useState<RoomAvailabilities>({
   //   H201: [],
@@ -41,8 +42,7 @@ const CancelModal: React.FC<CancelModalProps> = ({
   // });
 
   // const [selectedRoom, setSelectedRoom] = useState<string | null>(null);
-
-  const addRoomBooking = useAddRoomBookingHook();
+  const deleteRoomBooking = useDeleteBookingHook();
 
   // const { data: roomAvailabilities, isLoading } = useFetchAvailabilitiesHook(startWeek, endWeek);
 
@@ -62,35 +62,37 @@ const CancelModal: React.FC<CancelModalProps> = ({
 
   // const roomString = selectedRoom ?? "No Room Selected"
 
-  async function handleBooking(
-    userIdx: string,
-    roomx: string,
-    startx: Date,
-    endx: Date,
-    hasConfirmedx: boolean,
-    emailx: string,
-    created: Date,
-  ) {
-    const newBooking = {
-      userId: userIdx,
-      room: roomx,
-      startTime: startx,
-      endTime: endx,
-      hasConfirmed: hasConfirmedx,
-      email: emailx,
-      createdDate: created,
-    };
+  // async function handleBooking(
+  //   idx: string,
+  // ) {
+  //   const newBooking = {
+  //     userId: userIdx,
+  //     room: roomx,
+  //     startTime: startx,
+  //     endTime: endx,
+  //     hasConfirmed: hasConfirmedx,
+  //     email: emailx,
+  //     createdDate: created,
+  //   };
 
-    try {
-      await addRoomBooking.mutateAsync(newBooking);
-      // eslint-disable-next-line no-console
-      console.log('Room booked successfully!');
-    } catch (error) {
-      // eslint-disable-next-line no-console
-      console.error('Failed to book room:', error);
-    }
-    onClose();
-  }
+  //   const cancel = {
+  //     booking_id: idx,
+  //   }
+
+  // const bookingTooltipContent = `${booking.room}, ${formattedStartTime.toISOString().split('T')[1].substring(0, 5)}-${formattedEndTime.toISOString().split('T')[1].substring(0, 5)}`;
+
+  const handleDeleteBooking = (bookingId: string) => {
+    deleteRoomBooking.mutate(bookingId, {
+      onSuccess: () => {
+        toast(
+          `Successfully deleted booking in room ${userRoom}. Refresh to see updated list.`,
+        );
+      },
+      onError: () => {
+        toast(`Error: booking in room ${userRoom} not deleted`);
+      },
+    });
+  };
 
   function getDuration(startTime: Date, endTime: Date) {
     const timeMin = differenceInMinutes(endTime, startTime);
@@ -146,15 +148,8 @@ const CancelModal: React.FC<CancelModalProps> = ({
           <button
             className='rounded-full bg-red-50 text-red-700 py-0.1 px-2 border-solid border-1 border-red-700 text-sm'
             onClick={() => {
-              handleBooking(
-                userId,
-                userRoom,
-                startTime,
-                endTime,
-                false,
-                email,
-                startOfDay(new Date()),
-              );
+              handleDeleteBooking((id || '').toString());
+              onClose();
             }}
           >
             <div className='flex'>

--- a/src/slices/hatch/booking-page/components/modals/ExpandModal.tsx
+++ b/src/slices/hatch/booking-page/components/modals/ExpandModal.tsx
@@ -11,6 +11,7 @@ type ExpandModalProps = {
   userRoom: string;
   userId: string;
   email: string;
+  id: string;
 };
 
 export type RoomAvailabilities = {
@@ -28,6 +29,7 @@ const ExpandModal: React.FC<ExpandModalProps> = ({
   userRoom,
   userId,
   email,
+  id,
   open,
   onClose,
 }) => {
@@ -62,14 +64,14 @@ const ExpandModal: React.FC<ExpandModalProps> = ({
         >
           X
         </button>
-        <h1 className='text-center mx mb-5'>More</h1>
+        <h1 className='text-center mx mb-5'>More Options</h1>
 
         <button
           className='border-solid border-2 rounded-lg px-5 py-5 m-3 bg-white border-black hover:bg-green-100 hover:text-green-600 hover:border-green-600'
           onClick={() => handleRebook()}
         >
           <div>
-            <b className='text-lg'>Rebook</b>
+            <b className='text-lg'>Rebook Booking</b>
           </div>
         </button>
 
@@ -78,7 +80,7 @@ const ExpandModal: React.FC<ExpandModalProps> = ({
           onClick={() => handleCancel()}
         >
           <div>
-            <b className='text-lg'>Cancel</b>
+            <b className='text-lg'>Cancel Booking</b>
           </div>
         </button>
       </div>
@@ -99,6 +101,7 @@ const ExpandModal: React.FC<ExpandModalProps> = ({
         userRoom={userRoom}
         userId={userId}
         email={email}
+        id={id}
       ></CancelModal>
     </div>
   );

--- a/src/slices/hatch/booking-page/components/modals/ExpandModal.tsx
+++ b/src/slices/hatch/booking-page/components/modals/ExpandModal.tsx
@@ -50,6 +50,7 @@ const ExpandModal: React.FC<ExpandModalProps> = ({
     <div
       className={`fixed inset-0 flex justify-center items-center transition-colors
           ${open ? 'visible bg-black/20' : 'invisible'}`}
+      style={{ position: 'absolute' }}
       onClick={onClose}
     >
       <div

--- a/src/slices/hatch/booking-page/components/modals/ExpandModal.tsx
+++ b/src/slices/hatch/booking-page/components/modals/ExpandModal.tsx
@@ -1,0 +1,107 @@
+import React, { useState } from 'react';
+
+import CancelModal from '@/slices/hatch/booking-page/components/modals/CancelModal';
+import RebookModal from '@/slices/hatch/booking-page/components/modals/RebookModal';
+
+type ExpandModalProps = {
+  open: boolean;
+  onClose: () => void;
+  startTime: Date;
+  endTime: Date;
+  userRoom: string;
+  userId: string;
+  email: string;
+};
+
+export type RoomAvailabilities = {
+  H201: string[];
+  H203: string[];
+  H205: string[];
+  H204A: string[];
+  H204B: string[];
+};
+
+// eslint-disable-next-line unused-imports/no-unused-vars
+const ExpandModal: React.FC<ExpandModalProps> = ({
+  startTime,
+  endTime,
+  userRoom,
+  userId,
+  email,
+  open,
+  onClose,
+}) => {
+  const [rebookOpen, setRebookOpen] = useState<boolean>(false);
+  const [cancelOpen, setCancelOpen] = useState<boolean>(false);
+
+  const handleCancel = () => {
+    setCancelOpen(true);
+    onClose();
+  };
+
+  const handleRebook = () => {
+    setRebookOpen(true);
+    onClose();
+  };
+
+  return (
+    <div
+      className={`fixed inset-0 flex justify-center items-center transition-colors
+          ${open ? 'visible bg-black/20' : 'invisible'}`}
+      onClick={onClose}
+    >
+      <div
+        className={`bg-white rounded-lg shadow p-8 transition-all max-w-2xl border-solid border-2 border-green-300 
+            ${open ? 'scale-100 opacity-100' : 'scale-110 opacity-0'}`}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <button
+          className='absolute top-2 right-2 py-0.5 px-2 border 
+              berder-neutral-200 rounded-md text-gray-400 bg-white hover:bg-gray-50 hover:text-gray-600'
+          onClick={onClose}
+        >
+          X
+        </button>
+        <h1 className='text-center mx mb-5'>More</h1>
+
+        <button
+          className='border-solid border-2 rounded-lg px-5 py-5 m-3 bg-white border-black hover:bg-green-100 hover:text-green-600 hover:border-green-600'
+          onClick={() => handleRebook()}
+        >
+          <div>
+            <b className='text-lg'>Rebook</b>
+          </div>
+        </button>
+
+        <button
+          className='border-solid border-2 rounded-lg px-5 py-5 m-3 bg-white border-black hover:bg-green-100 hover:text-green-600 hover:border-green-600'
+          onClick={() => handleCancel()}
+        >
+          <div>
+            <b className='text-lg'>Cancel</b>
+          </div>
+        </button>
+      </div>
+      <RebookModal
+        open={rebookOpen}
+        onClose={() => setRebookOpen(false)}
+        startTime={startTime}
+        endTime={endTime}
+        userRoom={userRoom}
+        userId={userId}
+        email={email}
+      ></RebookModal>
+      <CancelModal
+        open={cancelOpen}
+        onClose={() => setCancelOpen(false)}
+        startTime={startTime}
+        endTime={endTime}
+        userRoom={userRoom}
+        userId={userId}
+        email={email}
+      ></CancelModal>
+    </div>
+  );
+};
+
+export default ExpandModal;

--- a/src/slices/hatch/booking-page/components/modals/RebookModal.tsx
+++ b/src/slices/hatch/booking-page/components/modals/RebookModal.tsx
@@ -5,7 +5,6 @@ import {
   isBefore,
   startOfDay,
   subDays,
-  subMinutes,
 } from 'date-fns';
 import React, { useEffect, useState } from 'react';
 
@@ -80,25 +79,24 @@ const RebookModal: React.FC<RebookModalProps> = ({
   ): boolean {
     const today = startOfDay(new Date());
     const isBeforeTd = isBefore(subDays(startTime, 1), today);
-    const temp = numTimes;
-    // console.log("ideal", numTimes)
-    // console.log(availabilities.H201, Object.values(availabilities).length)
     if (!isBeforeTd) {
       return Object.values(availabilities).some(
-        (availability) => Number(availability.length) > Number(temp),
+        (availability) => Number(availability.length) === Number(numTimes + 1),
       );
+    } else {
+      return false;
     }
-    return false;
   }
 
   function sameWeekAvail(
     room: keyof RoomAvailabilities,
     startTime: Date,
+    numTimes: number,
   ): boolean {
     const avail = availabilities2[room];
     const today = startOfDay(new Date());
     const isBeforeTd = isBefore(subDays(startTime, 1), today);
-    return !isBeforeTd && Array.isArray(avail) && avail.length !== 0;
+    return !isBeforeTd && Array.isArray(avail) && avail.length === numTimes;
   }
 
   const [availabilities1, setAvailabilities1] = useState<RoomAvailabilities>({
@@ -119,11 +117,10 @@ const RebookModal: React.FC<RebookModalProps> = ({
 
   const minBtwn = differenceInMinutes(startTime, endTime);
   const halfHoursBtwn = Math.abs(minBtwn / 30);
-  const endTimeReal = subMinutes(endTime, 30);
   const startTmrw = addDays(startTime, 1);
-  const endTmrw = addDays(endTimeReal, 1);
+  const endTmrw = addDays(endTime, 1);
   const startWeek = addDays(startTime, 7);
-  const endWeek = addDays(endTimeReal, 7);
+  const endWeek = addDays(endTime, 7);
 
   const { data: roomAvailabilities1, isLoading: isLoading1 } =
     useFetchAvailabilitiesHook(startTmrw, endTmrw);
@@ -221,12 +218,16 @@ const RebookModal: React.FC<RebookModalProps> = ({
 
         <button
           className={`border-solid border-2 rounded-lg px-5 py-5 m-3
-            ${sameWeekAvail(userRoom as keyof RoomAvailabilities, startWeek) ? 'bg-white border-gray-600 hover:bg-green-100 hover:text-green-600 hover:border-green-600' : 'bg-gray-50 border-gray-300 text-gray-300'}
+            ${sameWeekAvail(userRoom as keyof RoomAvailabilities, startWeek, halfHoursBtwn) ? 'bg-white border-gray-600 hover:bg-green-100 hover:text-green-600 hover:border-green-600' : 'bg-gray-50 border-gray-300 text-gray-300'}
             `}
           onClick={() =>
             handleButtonClick(
               '3',
-              sameWeekAvail(userRoom as keyof RoomAvailabilities, startWeek),
+              sameWeekAvail(
+                userRoom as keyof RoomAvailabilities,
+                startWeek,
+                halfHoursBtwn,
+              ),
             )
           }
         >

--- a/src/slices/hatch/booking-page/components/modals/RebookModal.tsx
+++ b/src/slices/hatch/booking-page/components/modals/RebookModal.tsx
@@ -5,6 +5,7 @@ import {
   isBefore,
   startOfDay,
   subDays,
+  subMinutes,
 } from 'date-fns';
 import React, { useEffect, useState } from 'react';
 
@@ -75,12 +76,16 @@ const RebookModal: React.FC<RebookModalProps> = ({
   function isAvail(
     availabilities: RoomAvailabilities,
     startTime: Date,
+    numTimes: number,
   ): boolean {
     const today = startOfDay(new Date());
     const isBeforeTd = isBefore(subDays(startTime, 1), today);
+    const temp = numTimes;
+    // console.log("ideal", numTimes)
+    // console.log(availabilities.H201, Object.values(availabilities).length)
     if (!isBeforeTd) {
       return Object.values(availabilities).some(
-        (availability) => availability.length !== 0,
+        (availability) => Number(availability.length) > Number(temp),
       );
     }
     return false;
@@ -112,10 +117,13 @@ const RebookModal: React.FC<RebookModalProps> = ({
     H204B: [],
   });
 
+  const minBtwn = differenceInMinutes(startTime, endTime);
+  const halfHoursBtwn = Math.abs(minBtwn / 30);
+  const endTimeReal = subMinutes(endTime, 30);
   const startTmrw = addDays(startTime, 1);
-  const endTmrw = addDays(endTime, 1);
+  const endTmrw = addDays(endTimeReal, 1);
   const startWeek = addDays(startTime, 7);
-  const endWeek = addDays(endTime, 7);
+  const endWeek = addDays(endTimeReal, 7);
 
   const { data: roomAvailabilities1, isLoading: isLoading1 } =
     useFetchAvailabilitiesHook(startTmrw, endTmrw);
@@ -157,10 +165,13 @@ const RebookModal: React.FC<RebookModalProps> = ({
 
         <button
           className={`border-solid border-2 rounded-lg px-5 py-5 m-3
-              ${isAvail(availabilities1, startTmrw) ? 'bg-white border-gray-600 hover:bg-green-100 hover:text-green-600 hover:border-green-600' : 'bg-gray-50 border-gray-300 text-gray-300'}
+              ${isAvail(availabilities1, startTmrw, halfHoursBtwn) ? 'bg-white border-gray-600 hover:bg-green-100 hover:text-green-600 hover:border-green-600' : 'bg-gray-50 border-gray-300 text-gray-300'}
               `}
           onClick={() =>
-            handleButtonClick('1', isAvail(availabilities1, startTmrw))
+            handleButtonClick(
+              '1',
+              isAvail(availabilities1, startTmrw, halfHoursBtwn),
+            )
           }
         >
           <div>
@@ -184,10 +195,13 @@ const RebookModal: React.FC<RebookModalProps> = ({
 
         <button
           className={`border-solid border-2 rounded-lg px-5 py-5 m-3
-            ${isAvail(availabilities2, startWeek) ? 'bg-white border-gray-600 hover:bg-green-100 hover:text-green-600 hover:border-green-600' : 'bg-gray-50 border-gray-300 text-gray-300'}
+            ${isAvail(availabilities2, startWeek, halfHoursBtwn) ? 'bg-white border-gray-600 hover:bg-green-100 hover:text-green-600 hover:border-green-600' : 'bg-gray-50 border-gray-300 text-gray-300'}
             `}
           onClick={() =>
-            handleButtonClick('2', isAvail(availabilities2, startWeek))
+            handleButtonClick(
+              '2',
+              isAvail(availabilities2, startWeek, halfHoursBtwn),
+            )
           }
         >
           <div>

--- a/src/slices/hatch/booking-page/components/modals/SameRoomModal.tsx
+++ b/src/slices/hatch/booking-page/components/modals/SameRoomModal.tsx
@@ -1,5 +1,6 @@
 import { addDays, differenceInMinutes, format, startOfDay } from 'date-fns';
 import { Bookmark } from 'lucide-react';
+import { toast } from 'sonner';
 
 import { useAddRoomBookingHook } from '@/slices/hatch/booking-page/hooks/bookingHooks';
 
@@ -83,14 +84,14 @@ const SameRoomModal: React.FC<SameRoomModalProps> = ({
       createdDate: created,
     };
 
-    try {
-      await addRoomBooking.mutateAsync(newBooking);
-      // eslint-disable-next-line no-console
-      console.log('Room booked successfully!');
-    } catch (error) {
-      // eslint-disable-next-line no-console
-      console.error('Failed to book room:', error);
-    }
+    addRoomBooking.mutate(newBooking, {
+      onSuccess: () => {
+        toast('Booking success. Refresh to see updated list.');
+      },
+      onError: () => {
+        toast('Room booking was unsuccessful.');
+      },
+    });
     onClose();
   }
 

--- a/src/slices/hatch/booking-page/components/modals/TomorrowModal.tsx
+++ b/src/slices/hatch/booking-page/components/modals/TomorrowModal.tsx
@@ -47,6 +47,8 @@ const TomorrowModal: React.FC<TomorrowModalProps> = ({
   const addRoomBooking = useAddRoomBookingHook();
   const startTmrw = addDays(startTime, 1);
   const endTmrw = addDays(endTime, 1);
+  const minBtwn = differenceInMinutes(startTime, endTime);
+  const halfHoursBtwn = Math.abs(minBtwn / 30);
 
   const { data: roomAvailabilities, isLoading } = useFetchAvailabilitiesHook(
     startTmrw,
@@ -114,9 +116,10 @@ const TomorrowModal: React.FC<TomorrowModalProps> = ({
   function isAvail(
     availabilities: RoomAvailabilities,
     room: keyof RoomAvailabilities,
+    numSlots: number,
   ): boolean {
     const roomTimes = availabilities[room];
-    return roomTimes.length != 0;
+    return roomTimes.length === numSlots + 1;
   }
 
   const roomButtonClass = (room: string, av: boolean) =>
@@ -175,10 +178,13 @@ const TomorrowModal: React.FC<TomorrowModalProps> = ({
               <button
                 className={roomButtonClass(
                   'H201',
-                  isAvail(availabilities, 'H201'),
+                  isAvail(availabilities, 'H201', halfHoursBtwn),
                 )}
                 onClick={() => {
-                  handleRoomSelection('H201', isAvail(availabilities, 'H201'));
+                  handleRoomSelection(
+                    'H201',
+                    isAvail(availabilities, 'H201', halfHoursBtwn),
+                  );
                 }}
               >
                 H201
@@ -187,10 +193,13 @@ const TomorrowModal: React.FC<TomorrowModalProps> = ({
               <button
                 className={roomButtonClass(
                   'H203',
-                  isAvail(availabilities, 'H203'),
+                  isAvail(availabilities, 'H203', halfHoursBtwn),
                 )}
                 onClick={() => {
-                  handleRoomSelection('H203', isAvail(availabilities, 'H203'));
+                  handleRoomSelection(
+                    'H203',
+                    isAvail(availabilities, 'H203', halfHoursBtwn),
+                  );
                   // eslint-disable-next-line no-console
                   console.log(roomString);
                 }}
@@ -201,10 +210,13 @@ const TomorrowModal: React.FC<TomorrowModalProps> = ({
               <button
                 className={roomButtonClass(
                   'H205',
-                  isAvail(availabilities, 'H205'),
+                  isAvail(availabilities, 'H205', halfHoursBtwn),
                 )}
                 onClick={() => {
-                  handleRoomSelection('H205', isAvail(availabilities, 'H205'));
+                  handleRoomSelection(
+                    'H205',
+                    isAvail(availabilities, 'H205', halfHoursBtwn),
+                  );
                   // eslint-disable-next-line no-console
                   console.log(roomString);
                 }}
@@ -214,12 +226,12 @@ const TomorrowModal: React.FC<TomorrowModalProps> = ({
               <button
                 className={roomButtonClass(
                   'H204A',
-                  isAvail(availabilities, 'H204A'),
+                  isAvail(availabilities, 'H204A', halfHoursBtwn),
                 )}
                 onClick={() => {
                   handleRoomSelection(
                     'H204A',
-                    isAvail(availabilities, 'H204A'),
+                    isAvail(availabilities, 'H204A', halfHoursBtwn),
                   );
                 }}
               >
@@ -228,12 +240,12 @@ const TomorrowModal: React.FC<TomorrowModalProps> = ({
               <button
                 className={roomButtonClass(
                   'H204B',
-                  isAvail(availabilities, 'H204B'),
+                  isAvail(availabilities, 'H204B', halfHoursBtwn),
                 )}
                 onClick={() => {
                   handleRoomSelection(
                     'H204B',
-                    isAvail(availabilities, 'H204B'),
+                    isAvail(availabilities, 'H204B', halfHoursBtwn),
                   );
                 }}
               >

--- a/src/slices/hatch/booking-page/components/modals/WeekModal.tsx
+++ b/src/slices/hatch/booking-page/components/modals/WeekModal.tsx
@@ -46,6 +46,8 @@ const WeekModal: React.FC<WeekModalProps> = ({
   const addRoomBooking = useAddRoomBookingHook();
   const startWeek = addDays(startTime, 7);
   const endWeek = addDays(endTime, 7);
+  const minBtwn = differenceInMinutes(startTime, endTime);
+  const halfHoursBtwn = Math.abs(minBtwn / 30);
 
   const { data: roomAvailabilities, isLoading } = useFetchAvailabilitiesHook(
     startWeek,
@@ -113,9 +115,10 @@ const WeekModal: React.FC<WeekModalProps> = ({
   function isAvail(
     availabilities: RoomAvailabilities,
     room: keyof RoomAvailabilities,
+    numSlots: number,
   ): boolean {
     const roomTimes = availabilities[room];
-    return roomTimes.length != 0;
+    return roomTimes.length === numSlots + 1;
   }
 
   const roomButtonClass = (room: string, av: boolean) =>
@@ -175,10 +178,13 @@ const WeekModal: React.FC<WeekModalProps> = ({
               <button
                 className={roomButtonClass(
                   'H201',
-                  isAvail(availabilities, 'H201'),
+                  isAvail(availabilities, 'H201', halfHoursBtwn),
                 )}
                 onClick={() => {
-                  handleRoomSelection('H201', isAvail(availabilities, 'H201'));
+                  handleRoomSelection(
+                    'H201',
+                    isAvail(availabilities, 'H201', halfHoursBtwn),
+                  );
                 }}
               >
                 H201
@@ -187,10 +193,13 @@ const WeekModal: React.FC<WeekModalProps> = ({
               <button
                 className={roomButtonClass(
                   'H203',
-                  isAvail(availabilities, 'H203'),
+                  isAvail(availabilities, 'H203', halfHoursBtwn),
                 )}
                 onClick={() => {
-                  handleRoomSelection('H203', isAvail(availabilities, 'H203'));
+                  handleRoomSelection(
+                    'H203',
+                    isAvail(availabilities, 'H203', halfHoursBtwn),
+                  );
                   // eslint-disable-next-line no-console
                   console.log(roomString);
                 }}
@@ -201,10 +210,13 @@ const WeekModal: React.FC<WeekModalProps> = ({
               <button
                 className={roomButtonClass(
                   'H205',
-                  isAvail(availabilities, 'H205'),
+                  isAvail(availabilities, 'H205', halfHoursBtwn),
                 )}
                 onClick={() => {
-                  handleRoomSelection('H205', isAvail(availabilities, 'H205'));
+                  handleRoomSelection(
+                    'H205',
+                    isAvail(availabilities, 'H205', halfHoursBtwn),
+                  );
                   // eslint-disable-next-line no-console
                   console.log(roomString);
                 }}
@@ -214,12 +226,12 @@ const WeekModal: React.FC<WeekModalProps> = ({
               <button
                 className={roomButtonClass(
                   'H204A',
-                  isAvail(availabilities, 'H204A'),
+                  isAvail(availabilities, 'H204A', halfHoursBtwn),
                 )}
                 onClick={() => {
                   handleRoomSelection(
                     'H204A',
-                    isAvail(availabilities, 'H204A'),
+                    isAvail(availabilities, 'H204A', halfHoursBtwn),
                   );
                 }}
               >
@@ -228,12 +240,12 @@ const WeekModal: React.FC<WeekModalProps> = ({
               <button
                 className={roomButtonClass(
                   'H204B',
-                  isAvail(availabilities, 'H204B'),
+                  isAvail(availabilities, 'H204B', halfHoursBtwn),
                 )}
                 onClick={() => {
                   handleRoomSelection(
                     'H204B',
-                    isAvail(availabilities, 'H204B'),
+                    isAvail(availabilities, 'H204B', halfHoursBtwn),
                   );
                 }}
               >


### PR DESCRIPTION
# Description & Technical Solution

- Created expand modal to give options to cancel or rebook
- Added cancel feature to expand options, so that users can cancel bookings through the dashboard
- Fixed rebooking overlapping bookings issue

# Questions / Things that still need to be added:
- Change expand modal to smaller object next to expand button
- The user dashboard isn't currently adding rebooks to the list immediately after the confirmation message (though this could be a local host issue)
- Add "confirm booking" options

# Checklist
- [x] Rebased against main branch.

# Screenshots
![image](https://github.com/user-attachments/assets/30605fee-7b0e-48ed-8cc2-f73bced5f462)
![image](https://github.com/user-attachments/assets/64a68990-e673-4b6d-a8ff-0e03383adfb4)

# Issue number

Resolves #287 
