### PR TITLE
Allow admin to select fully booked timeslots

### DIFF
--- a/src/slices/hatch/booking-page/components/TimePicker.tsx
+++ b/src/slices/hatch/booking-page/components/TimePicker.tsx
@@ -429,7 +429,7 @@ function TimePickerTable({
       // new slots to add to selection
       if (
         slotIndex < startIndex &&
-        allSlotsBetweenIndexesAreAvailable(startIndex, slotIndex) &&
+        // allSlotsBetweenIndexesAreAvailable(startIndex, slotIndex) &&
         // ~~ is a double bitwise NOT operator, which operates as a faster Math.floor() for positive numbers
         ~~(startIndex / timeslotsPerDay) == ~~(slotIndex / timeslotsPerDay)
       ) {
@@ -437,7 +437,7 @@ function TimePickerTable({
         setStartIndex(newStartIndex);
       } else if (
         slotIndex > endIndex &&
-        allSlotsBetweenIndexesAreAvailable(endIndex, slotIndex) &&
+        // allSlotsBetweenIndexesAreAvailable(endIndex, slotIndex) &&
         ~~(startIndex / timeslotsPerDay) == ~~(slotIndex / timeslotsPerDay)
       ) {
         const newEndIndex = slotIndex;
@@ -544,14 +544,30 @@ function TimePickerTable({
         {timeslots.map((slot, i) =>
           daysToShow.map((day, j) => {
             const timeSlotIndex = j * timeslots.length + i;
+
+            if (adminView) {
+              return (
+                <div
+                  key={`${day} ${slot}`}
+                  id={timeSlotIndex.toString()} // don't change (id is used to convert touch event to timeSlotIndex)
+                  className={`relative flex-1 touch-none border-1 border-b-0 border-black/20
+                    ${slotIsSelected(timeSlotIndex) && 'bg-[#CAFFB1]/50'}
+                    ${i % 2 === 1 && 'border-t-0'}
+                    border-l-0
+                    ${j === numDaysToShow - 1 && 'border-r-0'}`}
+                  onPointerDown={() => handleMouseDown(timeSlotIndex)}
+                  onPointerEnter={() => handleDrag(timeSlotIndex)}
+                />
+              );
+            }
             return (
               <div
                 key={`${day} ${slot}`}
                 id={timeSlotIndex.toString()} // don't change (id is used to convert touch event to timeSlotIndex)
                 className={`relative flex-1 touch-none border-1 border-b-0 border-black/20
-                      ${slotIsSelected(timeSlotIndex) && 'bg-[#CAFFB1]/50'} 
-                      ${!atLeastOneRoomAvailable(timeSlotIndex) && 'bg-[#CACED1]/40'} 
-                      ${i % 2 === 1 && 'border-t-0'} 
+                      ${slotIsSelected(timeSlotIndex) && 'bg-[#CAFFB1]/50'}
+                      ${!atLeastOneRoomAvailable(timeSlotIndex) && 'bg-[#CACED1]/40'}
+                      ${i % 2 === 1 && 'border-t-0'}
                       border-l-0
                       ${j === numDaysToShow - 1 && 'border-r-0'}`}
                 onPointerDown={() => handleMouseDown(timeSlotIndex)}

--- a/src/slices/hatch/booking-page/components/TimePicker.tsx
+++ b/src/slices/hatch/booking-page/components/TimePicker.tsx
@@ -366,7 +366,7 @@ function TimePickerTable({
       const newEndIndex = Math.max(endIndex, slotIndex);
       setStartIndex(newStartIndex);
       setEndIndex(newEndIndex);
-    } else if (atLeastOneRoomAvailable(slotIndex)) {
+    } else {
       // starting to select a new block
       dragOperationRef.current = 'Selecting';
       setStartIndex(slotIndex);
@@ -429,7 +429,6 @@ function TimePickerTable({
       // new slots to add to selection
       if (
         slotIndex < startIndex &&
-        // allSlotsBetweenIndexesAreAvailable(startIndex, slotIndex) &&
         // ~~ is a double bitwise NOT operator, which operates as a faster Math.floor() for positive numbers
         ~~(startIndex / timeslotsPerDay) == ~~(slotIndex / timeslotsPerDay)
       ) {
@@ -437,7 +436,6 @@ function TimePickerTable({
         setStartIndex(newStartIndex);
       } else if (
         slotIndex > endIndex &&
-        // allSlotsBetweenIndexesAreAvailable(endIndex, slotIndex) &&
         ~~(startIndex / timeslotsPerDay) == ~~(slotIndex / timeslotsPerDay)
       ) {
         const newEndIndex = slotIndex;
@@ -545,28 +543,13 @@ function TimePickerTable({
           daysToShow.map((day, j) => {
             const timeSlotIndex = j * timeslots.length + i;
 
-            if (adminView) {
-              return (
-                <div
-                  key={`${day} ${slot}`}
-                  id={timeSlotIndex.toString()} // don't change (id is used to convert touch event to timeSlotIndex)
-                  className={`relative flex-1 touch-none border-1 border-b-0 border-black/20
-                    ${slotIsSelected(timeSlotIndex) && 'bg-[#CAFFB1]/50'}
-                    ${i % 2 === 1 && 'border-t-0'}
-                    border-l-0
-                    ${j === numDaysToShow - 1 && 'border-r-0'}`}
-                  onPointerDown={() => handleMouseDown(timeSlotIndex)}
-                  onPointerEnter={() => handleDrag(timeSlotIndex)}
-                />
-              );
-            }
             return (
               <div
                 key={`${day} ${slot}`}
                 id={timeSlotIndex.toString()} // don't change (id is used to convert touch event to timeSlotIndex)
                 className={`relative flex-1 touch-none border-1 border-b-0 border-black/20
                       ${slotIsSelected(timeSlotIndex) && 'bg-[#CAFFB1]/50'}
-                      ${!atLeastOneRoomAvailable(timeSlotIndex) && 'bg-[#CACED1]/40'}
+                      ${adminView ? '' : !atLeastOneRoomAvailable(timeSlotIndex) && 'bg-[#CACED1]/40'}
                       ${i % 2 === 1 && 'border-t-0'}
                       border-l-0
                       ${j === numDaysToShow - 1 && 'border-r-0'}`}


### PR DESCRIPTION
# Description & Technical Solution

Modify `handleMouseDownAdmin` and `handleDragAdmin` to allow admin to select or drag timeslots that are booked for every available room. Also, remove the greyed-out timeslot feature for the admin view.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] Already rebased against main branch.

# Screenshots

https://github.com/user-attachments/assets/36ab7cad-c802-42d3-9616-1cf586251bf7

# Issue number

Closes #319 
