### PR TITLE
Fix messages from available rooms component

### DIFF
--- a/src/slices/hatch/booking-page/components/AvailableRooms.tsx
+++ b/src/slices/hatch/booking-page/components/AvailableRooms.tsx
@@ -32,9 +32,9 @@ export default function AvailableRooms({ className }: { className?: string }) {
           <div className='flex h-full w-full items-center justify-center p-4 text-center font-bold'>
             Booking can only be made within two weeks
           </div>
-        ) : !startIndex || (startIndex && numAvailRooms === 0) ? (
+        ) : startIndex == -1 || (startIndex != -1 && numAvailRooms === 0) ? (
           <div className='flex h-full w-full items-center justify-center p-4 text-center font-bold'>
-            {startIndex
+            {startIndex != -1
               ? numAvailRooms === 0
                 ? 'No Rooms Available'
                 : null

--- a/src/slices/hatch/booking-page/components/AvailableRooms.tsx
+++ b/src/slices/hatch/booking-page/components/AvailableRooms.tsx
@@ -35,7 +35,8 @@ export default function AvailableRooms({ className }: { className?: string }) {
         ) : startIndex == -1 || (startIndex != -1 && numAvailRooms === 0) ? (
           <div className='flex h-full w-full items-center justify-center p-4 text-center font-bold'>
             {startIndex != -1
-              ? numAvailRooms === 0
+              ? // && !checkBookingNotInPast() added here as a band-aid solution to prevent 'No Rooms Available' flashing when selecting a timeslot with rooms available
+                numAvailRooms === 0 && !checkBookingNotInPast()
                 ? 'No Rooms Available'
                 : null
               : 'Click/drag to select a time'}

--- a/src/slices/hatch/booking-page/context/TimePickerContext.tsx
+++ b/src/slices/hatch/booking-page/context/TimePickerContext.tsx
@@ -174,7 +174,8 @@ export const TimePickerProvider = ({ children }: Props) => {
   const checkBookingNotInPast = useCallback(() => {
     pickerEndDate.setDate(pickerStartDate.getDate() + 6);
     if (
-      (startIndex && timeSlotIndexToTimeISODate(startIndex) < new Date()) ||
+      (startIndex != -1 &&
+        timeSlotIndexToTimeISODate(startIndex) < new Date()) ||
       (pickerEndDate && pickerEndDate < new Date())
     ) {
       return false;


### PR DESCRIPTION
# Description & Technical Solution

Prevent the `AvailableRooms` component from displaying inaccurate messages. The issue stemmed from the previous code assuming that `startIndex` is 0 when nothing is selected on the time picker, when `startIndex` is actually -1.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] Already rebased against main branch.

# Screenshots

https://github.com/user-attachments/assets/188147c8-0abb-43db-95f3-2b84061d228e

# Issue number

Closes #286 
