### PR TITLE
feat: add 11pm to bottom of time picker calendar

### DIFF
--- a/src/slices/hatch/booking-page/components/TimePicker.tsx
+++ b/src/slices/hatch/booking-page/components/TimePicker.tsx
@@ -485,7 +485,7 @@ function TimePickerTable({
   const TimeIndicators = memo(() => {
     /* time indicators along the side */
     return (
-      <div className='mr-1 mt-14 flex flex-col justify-stretch'>
+      <div className='mr-1 mt-14 flex flex-col justify-stretch relative'>
         {timeslots.map((slot: string, i) => {
           if (i % 2 === 1) return null;
           return (
@@ -498,6 +498,13 @@ function TimePickerTable({
             </span>
           );
         })}
+        {/* Manually add 11pm since we don't want it to be in timeslots. */}
+        <span
+          id='time-text-11 PM'
+          className='absolute bottom-0 translate-y-[8px] whitespace-nowrap text-right text-xs italic text-[#373A36]/80'
+        >
+          11 PM
+        </span>
       </div>
     );
   });


### PR DESCRIPTION
# Description & Technical Solution

Wanted to include 11pm at the bottom of the calendar. Had to make the timeslots a relative container instead of the default (static), and added 11 PM as a hardcoded value beneath the other timeslots, aligned to the bottom in absolute positioning. This is because adding 11pm to the timeslots array could have unintended consequences as `timeslots` can be used in many other applications related to the core booking logic. This way, it remains outside of that logic.

The spacing between 10 PM to 11 PM was made around 2px less than each other spacing. This was taken by measuring the distance from 9 PM to 10 PM as reference. I made it slightly closer due to the shape of the timepicker table where it looked like it was too far away if I had it the full 10 px below. Keeping it at 8px looked better and didn't seem noticeable; nothing looked off when viewing the page.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] Already rebased against main branch.

# Screenshots

![image](https://github.com/user-attachments/assets/e350d0a1-9543-4c78-aaf8-20dbc922a3c0)

# Issue number

Closes #347
