### PR TITLE
Add more information to error page

### DIFF
--- a/src/app/auth/error/ErrorPage.tsx
+++ b/src/app/auth/error/ErrorPage.tsx
@@ -6,6 +6,7 @@ import * as React from 'react';
 import { RiAlarmWarningFill } from 'react-icons/ri';
 
 import PageLayout from '@/components/layout/PageLayout';
+import ButtonLink from '@/components/links/ButtonLink';
 
 export function ErrorPage() {
   const searchParams = useSearchParams();
@@ -15,16 +16,15 @@ export function ErrorPage() {
   if (!error) {
     redirect('/auth/sign-in');
   }
+
   // eslint-disable-next-line no-console
-  console.log(error);
+  console.log('Someone had an error signing in:', error);
   return (
     <PageLayout>
       <main className='layout'>
         <section>
-          <div className='flex flex-col items-center min-h-screen'>
-            {' '}
-            {/*  bg-[hsl(0,0%,97.5%)]*/}
-            <div className='flex flex-col w-3/4 h-full rounded-t-lg shadow-md bg-white text-center items-center justify-center '>
+          <div className='flex flex-col items-center min-h-full'>
+            <div className='flex flex-col w-3/4 rounded-t-lg shadow-md bg-white text-center items-center justify-center '>
               <div className='flex flex-col items-center text-[hsl(0,45%,28%)] bg-red-400 rounded-t-lg w-full pb-14'>
                 <h1 className='flex flex-col items-center justify-center mt-10'>
                   <RiAlarmWarningFill
@@ -34,17 +34,25 @@ export function ErrorPage() {
                 </h1>
                 <h1 className='mt-5 mb-5'> Oops! </h1>
                 <h2 className='w-1/2 mb-5'>
-                  {' '}
-                  It looks like there was an error with signing in.{' '}
+                  It looks like there was an error with signing in.
                 </h2>
               </div>
-              <div className='w-5/6 p-8 rounded-lg items-center justify-center shadow-md bg-amber-200 text-center m-10'>
-                <div>
-                  <b>
-                    If you're not sure why you got the error, contact the
-                    administrator at ghc@mcmaster.ca
-                  </b>
-                </div>
+              <div className='flex flex-col w-5/6 pt-6 pb-4 m-8 rounded-lg items-center justify-center text-center shadow-md bg-amber-200'>
+                <b>
+                  Sign in again, then copy and paste the sign-in link into your
+                  browser
+                </b>
+                <ButtonLink
+                  variant='outline'
+                  href='/auth/sign-in'
+                  className='mt-2 w-1/4'
+                >
+                  Try Again
+                </ButtonLink>
+              </div>
+              <div className='w-5/6 justify-center text-center mb-8'>
+                If the error persists, contact the administrator at
+                ghc@mcmaster.ca
               </div>
             </div>
           </div>

--- a/src/app/auth/error/ErrorPage.tsx
+++ b/src/app/auth/error/ErrorPage.tsx
@@ -39,8 +39,8 @@ export function ErrorPage() {
               </div>
               <div className='flex flex-col w-5/6 pt-6 pb-4 m-8 rounded-lg items-center justify-center text-center shadow-md bg-amber-200'>
                 <b>
-                  Sign in again, then copy and paste the sign-in link into your
-                  browser
+                  To resolve this problem, sign in again and past the sign-in
+                  link from the email into the browser.
                 </b>
                 <ButtonLink
                   variant='outline'

--- a/src/app/auth/page.tsx
+++ b/src/app/auth/page.tsx
@@ -6,6 +6,7 @@ import Button from '@/components/buttons/Button';
 import PageLayout from '@/components/layout/PageLayout';
 import ButtonLink from '@/components/links/ButtonLink';
 import PageHeading from '@/components/PageHeading';
+import PageSection from '@/components/PageSection';
 
 // Example function to send an email
 async function sendEmail() {
@@ -32,6 +33,11 @@ export default function AuthPage() {
             title='Authentication!'
             variant='green'
           />
+          <PageSection>
+            This is a test page meant for helping test authentiation. If you are
+            a normal hatch user and somehow found this page, please disregard
+            it.
+          </PageSection>
           <Button onClick={sendEmail}>Send mail</Button>
           <SignOut />
           <ButtonLink href='/auth/sign-in'>Sign in</ButtonLink>


### PR DESCRIPTION
# Description & Technical Solution

@BaoGeist and I discussed that the error page could have a bit more information about what we want it to tell users, plus a button to try and sign in again.

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] Already rebased against main branch.

# Screenshots

![image](https://github.com/user-attachments/assets/13e27d79-9d9f-4024-b61b-1cba640a291f)

# Issue number

Closes #366
