### PR TITLE
[185, 341] Feature/validation in making booking

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
     "date-fns": "^3.6.0",
+    "date-fns-tz": "^3.2.0",
     "dotenv": "^16.4.5",
     "framer-motion": "^11.2.4",
     "lucide-react": "^0.376.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       date-fns:
         specifier: ^3.6.0
         version: 3.6.0
+      date-fns-tz:
+        specifier: ^3.2.0
+        version: 3.2.0(date-fns@3.6.0)
       dotenv:
         specifier: ^16.4.5
         version: 16.4.5
@@ -3461,6 +3464,11 @@ packages:
   data-view-byte-offset@1.0.0:
     resolution: {integrity: sha512-t/Ygsytq+R995EJ5PZlD4Cu56sWa8InXySaViRzw9apusqsOO2bQP+SbYzAhR0pFKoB+43lYy8rWban9JSuXnA==}
     engines: {node: '>= 0.4'}
+
+  date-fns-tz@3.2.0:
+    resolution: {integrity: sha512-sg8HqoTEulcbbbVXeg84u5UnlsQa8GS5QXMqjjYIhS4abEVVKIUwe0/l/UhrZdKaL/W5eWZNlbTeEIiOXTcsBQ==}
+    peerDependencies:
+      date-fns: ^3.0.0 || ^4.0.0
 
   date-fns@3.6.0:
     resolution: {integrity: sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==}
@@ -10635,6 +10643,10 @@ snapshots:
       call-bind: 1.0.7
       es-errors: 1.3.0
       is-data-view: 1.0.1
+
+  date-fns-tz@3.2.0(date-fns@3.6.0):
+    dependencies:
+      date-fns: 3.6.0
 
   date-fns@3.6.0: {}
 

--- a/src/app/api/bookings/add-booking/route.ts
+++ b/src/app/api/bookings/add-booking/route.ts
@@ -22,11 +22,12 @@ export async function POST(req: Request) {
   };
 
   try {
-    const newBooking = await createBookingService(adaptedBooking);
-    if (!newBooking) {
+    const { booking: newBooking, message } =
+      await createBookingService(adaptedBooking);
+    if (!newBooking && message) {
       return NextResponse.json<TMessageResponse>(
-        { message: 'Booking not found (booking error encountered)' },
-        { status: 404 },
+        { message: message },
+        { status: 409 },
       );
     }
     return NextResponse.json<TApiResponse<TBooking>>(

--- a/src/app/auth/success/page.tsx
+++ b/src/app/auth/success/page.tsx
@@ -29,8 +29,9 @@ export default function AuthSuccessPage() {
                 <div>
                   <b>Didn't receive an email?</b>
                   <div>
-                    Check your quarentine and spam messages within your email if
-                    you cannot find it. Add the email to trusted users.{' '}
+                    Check your email quarantine and spam messages if you're
+                    unable to locate a sign-in email. Add the email to trusted
+                    users for the future!{' '}
                   </div>
                   <p className='mb-2 mt-2'>
                     To go back to the sign in page and try again, follow the

--- a/src/slices/hatch/admin/apiCalls/bookingApiCalls.ts
+++ b/src/slices/hatch/admin/apiCalls/bookingApiCalls.ts
@@ -16,7 +16,7 @@ export async function fetchBatchAddBooking(
     const email = newBooking.email ?? (await getUserEmail());
     if (email == null) {
       throw new Error(
-        'No emailO was passed in for a new booking, nor is the user signed in to retrieve one from the current session.',
+        'No email was passed in for a new booking, nor is the user signed in to retrieve one from the current session.',
       );
     }
     newBooking.email = email;

--- a/src/slices/hatch/booking-page/apiCalls/bookingApiCalls.ts
+++ b/src/slices/hatch/booking-page/apiCalls/bookingApiCalls.ts
@@ -62,11 +62,15 @@ export async function fetchAddBooking(newBooking: TBooking): Promise<TBooking> {
     },
   );
 
-  if (!response.ok) {
+  if (!response.ok && response.status !== 409) {
     throw new Error(`Error: ${response.statusText}`);
   }
 
   const result = await response.json();
+
+  if (response.status === 409) {
+    throw new Error(`${result.message}`);
+  }
 
   return result.data;
 }

--- a/src/slices/hatch/booking-page/apiCalls/bookingApiCalls.ts
+++ b/src/slices/hatch/booking-page/apiCalls/bookingApiCalls.ts
@@ -62,12 +62,14 @@ export async function fetchAddBooking(newBooking: TBooking): Promise<TBooking> {
     },
   );
 
+  // Want to handle all errors but 409 here because 409 means there was a state issue where a booking couldn't be added (eg. already booked at that timeslot) which needs a different error message.
   if (!response.ok && response.status !== 409) {
     throw new Error(`Error: ${response.statusText}`);
   }
 
   const result = await response.json();
 
+  // Handle 409 errors here so they display the message we want to send back to the frontend properly.
   if (response.status === 409) {
     throw new Error(`${result.message}`);
   }

--- a/src/slices/hatch/booking-page/context/TimePickerContext.tsx
+++ b/src/slices/hatch/booking-page/context/TimePickerContext.tsx
@@ -202,8 +202,12 @@ export const TimePickerProvider = ({ children }: Props) => {
           onSuccess: () => {
             resolve('Room has been successfully booked.');
           },
-          onError: () => {
-            resolve('Room booking was unsuccessful.');
+          onError: (error: Error) => {
+            if (error.message.includes('Invalid booking')) {
+              resolve(error.message);
+            } else {
+              resolve('Room booking was unsuccessful.');
+            }
           },
         });
       });

--- a/src/slices/hatch/booking-page/db/bookingDb.ts
+++ b/src/slices/hatch/booking-page/db/bookingDb.ts
@@ -15,14 +15,10 @@ const getBookingsCollection = async () => {
 
 export const createBookingDb = async (
   newBooking: TBookingDb,
-  disabledRooms: string[],
 ): Promise<TBookingDb> => {
   try {
     const bookingsCollection = await getBookingsCollection();
 
-    if (disabledRooms?.includes(newBooking.room)) {
-      throw new Error('Room is disabled.');
-    }
     newBooking.createdDate = new Date();
     const result: InsertOneResult =
       await bookingsCollection.insertOne(newBooking);

--- a/src/slices/hatch/booking-page/services/addBookingValidators.ts
+++ b/src/slices/hatch/booking-page/services/addBookingValidators.ts
@@ -2,7 +2,10 @@ import { TBookingDb } from '@/app/api/types';
 import { getDisabledRoomsService } from '@/slices/hatch/admin/services/roomServices';
 import { getBookingsInDateRangeForOneRoomDb } from '@/slices/hatch/booking-page/db/bookingDb';
 import { getBookingsInDateRangeAndEmailService } from '@/slices/hatch/booking-page/services/bookingServices';
-import { getNumberOf30MinuteSlots } from '@/slices/hatch/booking-page/utils';
+import {
+  getESTDayBoundaries,
+  getNumberOf30MinuteSlots,
+} from '@/slices/hatch/booking-page/utils';
 
 const disabledRoomCheckService = async (
   newBooking: TBookingDb,
@@ -25,11 +28,17 @@ const disabledRoomCheckService = async (
 const threeHourRoomsCheckService = async (
   newBooking: TBookingDb,
 ): Promise<{ valid: boolean; message: string | null }> => {
-  const userBookingsOnDay = await getBookingsInDateRangeAndEmailService(
+  const { startOfDay, endOfDay } = getESTDayBoundaries(
     newBooking.startTime,
     newBooking.endTime,
+  );
+
+  const userBookingsOnDay = await getBookingsInDateRangeAndEmailService(
+    startOfDay,
+    endOfDay,
     newBooking.email,
   );
+
   if (userBookingsOnDay === null) {
     throw new Error("Error in fetching user's rooms");
   }

--- a/src/slices/hatch/booking-page/services/addBookingValidators.ts
+++ b/src/slices/hatch/booking-page/services/addBookingValidators.ts
@@ -1,0 +1,80 @@
+import { TBookingDb } from '@/app/api/types';
+import { getDisabledRoomsService } from '@/slices/hatch/admin/services/roomServices';
+import { getBookingsInDateRangeForOneRoomDb } from '@/slices/hatch/booking-page/db/bookingDb';
+import { getBookingsInDateRangeAndEmailService } from '@/slices/hatch/booking-page/services/bookingServices';
+import { getNumberOf30MinuteSlots } from '@/slices/hatch/booking-page/utils';
+
+const disabledRoomCheckService = async (
+  newBooking: TBookingDb,
+): Promise<{ valid: boolean; message: string | null }> => {
+  const disabledRooms = await getDisabledRoomsService();
+  if (disabledRooms === null) {
+    throw new Error('Error in fetching disabled rooms');
+  }
+
+  const roomEnabled = !disabledRooms.disabledRooms.includes(newBooking.room);
+
+  return {
+    valid: roomEnabled,
+    message: roomEnabled
+      ? null
+      : 'Invalid booking: Bookings for the room requested has been disabled',
+  };
+};
+
+const threeHourRoomsCheckService = async (
+  newBooking: TBookingDb,
+): Promise<{ valid: boolean; message: string | null }> => {
+  const userBookingsOnDay = await getBookingsInDateRangeAndEmailService(
+    newBooking.startTime,
+    newBooking.endTime,
+    newBooking.email,
+  );
+  if (userBookingsOnDay === null) {
+    throw new Error("Error in fetching user's rooms");
+  }
+
+  const userNumberOfSlotsOnDay =
+    getNumberOf30MinuteSlots(newBooking.startTime, newBooking.endTime) +
+    userBookingsOnDay.reduce(
+      (accumulator, currentValue) =>
+        accumulator +
+        getNumberOf30MinuteSlots(currentValue.startTime, currentValue.endTime),
+      0,
+    );
+
+  return {
+    valid: userNumberOfSlotsOnDay <= 6,
+    message:
+      userNumberOfSlotsOnDay <= 6
+        ? null
+        : 'Invalid booking: Bookings can only be made to a maximum of 3 hours',
+  };
+};
+
+const availableRoomsCheckService = async (
+  newBooking: TBookingDb,
+): Promise<{ valid: boolean; message: string | null }> => {
+  const roomBookings = await getBookingsInDateRangeForOneRoomDb(
+    newBooking.startTime,
+    newBooking.endTime,
+    newBooking.room,
+  );
+  if (roomBookings === null) {
+    throw new Error('Error in fetching available rooms');
+  }
+
+  return {
+    valid: roomBookings.length === 0,
+    message:
+      roomBookings.length === 0
+        ? null
+        : 'Invalid booking: Someone already booked this room before you! :P',
+  };
+};
+
+export const bookingValidationMethods = [
+  disabledRoomCheckService,
+  availableRoomsCheckService,
+  threeHourRoomsCheckService,
+];

--- a/src/slices/hatch/booking-page/services/bookingServices.ts
+++ b/src/slices/hatch/booking-page/services/bookingServices.ts
@@ -64,8 +64,7 @@ export const createBookingService = async (
     if (invalidCheck) {
       return {
         booking: null,
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        message: invalidCheck.message!,
+        message: invalidCheck.message,
       };
     }
 

--- a/src/slices/hatch/booking-page/services/bookingServices.ts
+++ b/src/slices/hatch/booking-page/services/bookingServices.ts
@@ -22,6 +22,7 @@ import {
   getBookingsInDateRangeForOneRoomDb,
   updateBookingByIdDb,
 } from '@/slices/hatch/booking-page/db/bookingDb';
+import { bookingValidationMethods } from '@/slices/hatch/booking-page/services/addBookingValidators';
 
 const availableRooms = ['H201', 'H203', 'H204A', 'H204B', 'H205'];
 
@@ -50,26 +51,31 @@ function adaptTBookingDbToTBooking(booking: TBookingDb): TBooking {
 
 export const createBookingService = async (
   newBooking: TBooking,
-): Promise<TBooking | null> => {
+): Promise<{ booking: TBooking | null; message: string | null }> => {
   try {
-    // Adapt booking type.
     const adaptedBooking = adaptTBookingToTBookingDb(newBooking);
 
-    const disabledRooms = await getDisabledRoomsService();
-    if (disabledRooms === null) {
-      throw new Error('Error in fetching disabled rooms');
-    } else {
-      const booking = await createBookingDb(
-        adaptedBooking,
-        disabledRooms.disabledRooms,
-      );
-      sendBookingConfirmationEmailService(booking);
-      return adaptTBookingDbToTBooking(booking);
+    const checkResults = await Promise.all(
+      bookingValidationMethods.map(async (check) => await check(newBooking)),
+    );
+
+    const invalidCheck = checkResults.find((result) => !result.valid);
+
+    if (invalidCheck) {
+      return {
+        booking: null,
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        message: invalidCheck.message!,
+      };
     }
+
+    const booking = await createBookingDb(adaptedBooking);
+    sendBookingConfirmationEmailService(booking);
+    return { booking: adaptTBookingDbToTBooking(booking), message: null };
   } catch (error) {
     /* eslint-disable no-console */
     console.error('Error in booking services:', error);
-    return null;
+    return { booking: null, message: null };
   }
 };
 

--- a/src/slices/hatch/booking-page/utils.ts
+++ b/src/slices/hatch/booking-page/utils.ts
@@ -1,4 +1,8 @@
-import { addMinutes, startOfDay } from 'date-fns';
+import { addMinutes, endOfWeek, startOfDay, startOfWeek } from 'date-fns';
+import { enGB } from 'date-fns/locale/en-GB';
+import { formatInTimeZone } from 'date-fns-tz';
+
+const timeZone = 'America/New_York'; // EST timezone
 
 export function add30Minutes(date: Date): Date {
   return addMinutes(date, 30);
@@ -8,8 +12,6 @@ export const formatDateForKey = (date: Date) =>
   startOfDay(date).toISOString().split('T')[0];
 
 export function getESTDayBoundaries(startTimeUTC: Date, endTimeUTC: Date) {
-  const timeZone = 'America/New_York'; // EST time zone
-
   // Convert UTC times to EST
   const startTimeEST = new Date(startTimeUTC).toLocaleString('en-US', {
     timeZone,
@@ -60,3 +62,21 @@ export const getNumberOf30MinuteSlots = (
   // Return the result plus one because times are indexed by the start time.
   return numberOfSlots + 1;
 };
+
+/**
+ * Returns the start and end of the week given an input date. It internally converts the dates to EST
+ * @param date Date to get the week of which it belongs in.
+ * @returns Date objects in format `{start, end}` for the week that the input date is within.
+ */
+export function getWeekRangeInEST(date: Date) {
+  // Convert UTC date to EST.
+  const estDate = formatInTimeZone(date, timeZone, 'yyyy-MM-dd HH:mm:ssXXX', {
+    locale: enGB,
+  });
+
+  // Get the start and end of the week in UTC (Sunday to Saturday).
+  const startOfWeekUTC = startOfWeek(estDate, { weekStartsOn: 0 });
+  const endOfWeekUTC = endOfWeek(estDate, { weekStartsOn: 0 });
+
+  return { startOfWeekUTC, endOfWeekUTC };
+}

--- a/src/slices/hatch/booking-page/utils.ts
+++ b/src/slices/hatch/booking-page/utils.ts
@@ -6,3 +6,57 @@ export function add30Minutes(date: Date): Date {
 
 export const formatDateForKey = (date: Date) =>
   startOfDay(date).toISOString().split('T')[0];
+
+export function getESTDayBoundaries(startTimeUTC: Date, endTimeUTC: Date) {
+  const timeZone = 'America/New_York'; // EST time zone
+
+  // Convert UTC times to EST
+  const startTimeEST = new Date(startTimeUTC).toLocaleString('en-US', {
+    timeZone,
+  });
+  const endTimeEST = new Date(endTimeUTC).toLocaleString('en-US', { timeZone });
+
+  // Create Date objects from the EST strings
+  const startDateEST = new Date(startTimeEST);
+  const endDateEST = new Date(endTimeEST);
+
+  // Get start of day for start time
+  const startOfDayEST = new Date(
+    startDateEST.getFullYear(),
+    startDateEST.getMonth(),
+    startDateEST.getDate(),
+  );
+
+  // Get end of day for end time
+  const endOfDayEST = new Date(
+    endDateEST.getFullYear(),
+    endDateEST.getMonth(),
+    endDateEST.getDate(),
+    23,
+    59,
+    59,
+    999,
+  );
+
+  return {
+    startOfDay: startOfDayEST,
+    endOfDay: endOfDayEST,
+  };
+}
+
+export const getNumberOf30MinuteSlots = (
+  startTime: Date,
+  endTime: Date,
+): number => {
+  // Get the difference in time between the end and start in milliseconds
+  const differenceInMs = endTime.getTime() - startTime.getTime();
+
+  // Convert the difference to minutes
+  const differenceInMinutes = differenceInMs / (1000 * 60);
+
+  // Divide by 30 to get the number of 30-minute timeslots
+  const numberOfSlots = differenceInMinutes / 30;
+
+  // Return the result plus one because times are indexed by the start time.
+  return numberOfSlots + 1;
+};


### PR DESCRIPTION
# Description & Technical Solution

When adding a booking, there is currently no backend validation. There are multiple cases where this is needed.

**The main case:**
The add-booking endpoint currently doesn't check before making a booking if there are any conflicting bookings. This use case would be hit when either someone directly pings the backend bypassing the frontend, or when two users book at similar times before either frontend has updated.

Other validations added:
- User cannot have more than 3 hours booked a day
- User cannot have more than 10 hours booked a week (Sunday to Saturday)
- Room must not be disabled

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] Already rebased against main branch.

# Screenshots


https://github.com/user-attachments/assets/ef59f7a5-26a7-422c-a153-3902de5b9c65

# Issue number

Closes #185, #341
