### PR TITLE
fix: add next public url to auth callback, fix wording on auth pages,…

### DIFF
--- a/src/app/auth/error/ErrorPage.tsx
+++ b/src/app/auth/error/ErrorPage.tsx
@@ -39,7 +39,7 @@ export function ErrorPage() {
               </div>
               <div className='flex flex-col w-5/6 pt-6 pb-4 m-8 rounded-lg items-center justify-center text-center shadow-md bg-amber-200'>
                 <b>
-                  To resolve this problem, sign in again and past the sign-in
+                  To resolve this problem, sign in again and paste the sign-in
                   link from the email into the browser.
                 </b>
                 <ButtonLink
@@ -52,7 +52,7 @@ export function ErrorPage() {
               </div>
               <div className='w-5/6 justify-center text-center mb-8'>
                 If the error persists, contact the administrator at
-                ghc@mcmaster.ca
+                infratech@macengsociety.ca
               </div>
             </div>
           </div>

--- a/src/app/auth/success/page.tsx
+++ b/src/app/auth/success/page.tsx
@@ -10,19 +10,15 @@ export default function AuthSuccessPage() {
         <section>
           <div className='flex flex-col items-center min-h-screen'>
             {' '}
-            {/*  bg-[hsl(0,0%,97.5%)]*/}
             <div className='flex flex-col w-3/4 h-full rounded-t-lg shadow-md bg-white text-center items-center justify-center '>
               <div className='flex flex-col items-center text-[hsl(124,100%,22%)] bg-[#A1D884] rounded-t-lg w-full pb-14'>
                 <h1 className='flex items-center justify-center mt-10'>
                   <RxCheckCircled className='mr-3 text-5xl' />
-                  Success!
+                  Almost there!
                 </h1>
                 <b className='mt-5'>
                   Please check your email inbox for the sign in link.
                 </b>
-                <ButtonLink href='/auth/sign-in' className='mt-8 w-1/2'>
-                  Continue
-                </ButtonLink>
               </div>
 
               <div className='w-5/6 p-8 rounded-lg items-center justify-center shadow-md bg-amber-200 text-center m-10'>

--- a/src/app/booking-system/BookingSystemPage.tsx
+++ b/src/app/booking-system/BookingSystemPage.tsx
@@ -8,27 +8,30 @@ export default function BookingPage() {
   return (
     <PageLayout noFooter>
       <>
-        <Alert className='h-[70px] sm:h-[50px]' severity='info'>
+        <Alert className='h-auto' severity='info'>
           We're planning to release our new booking system soon, but we need
           your help to test it out and make sure it's ready! If you have a few
-          minutes to spare, please check it out{' '}
-          <Link
-            href='https://macengsociety.ca/hatch-booking/new-booking'
-            target='_blank'
-            rel='noopener noreferrer'
-          >
-            here
-          </Link>{' '}
-          and let us know of any issues or suggestions you have at this
-          <Link
-            href='https://forms.gle/dbZq1rAYVgANM9Zr8'
-            target='_blank'
-            rel='noopener noreferrer'
-          >
-            {' '}
-            form
-          </Link>
-          !
+          minutes to spare,{' '}
+          <span className='underline'>
+            <Link
+              href='https://www.macengsociety.ca/auth/sign-in'
+              target='_blank'
+              rel='noopener noreferrer'
+            >
+              please check it out here
+            </Link>
+          </span>{' '}
+          and let us know of any issues or suggestions you have at{' '}
+          <span className='underline'>
+            <Link
+              href='https://forms.gle/dbZq1rAYVgANM9Zr8'
+              target='_blank'
+              rel='noopener noreferrer'
+            >
+              this form
+            </Link>
+            !
+          </span>
         </Alert>
 
         <iframe

--- a/src/app/hatch-booking/layout.tsx
+++ b/src/app/hatch-booking/layout.tsx
@@ -28,7 +28,7 @@ export default function NewBookingSystemLayout({
       <main>
         <PageLayout noFooter noBackground>
           <Alert
-            className='bg-primary-700 text-white h-[70px] sm:h-[50px]'
+            className='bg-primary-700 text-white h-auto'
             severity='info'
             icon={<InfoIcon className='text-primary-200' />}
           >

--- a/src/slices/auth/utils.ts
+++ b/src/slices/auth/utils.ts
@@ -32,7 +32,7 @@ export const handleEmailSignIn = async (email: string) => {
     // Perform the sign-in using nodemailer to send a magic link.
     await signIn('nodemailer', {
       email,
-      callbackUrl: '/hatch-booking/new-booking',
+      callbackUrl: process.env.NEXT_PUBLIC_URL + '/hatch-booking/new-booking',
     });
     errorThrown = false;
   } catch (error) {


### PR DESCRIPTION
# Description & Technical Solution

Improved issues with auth and links to items from the current booking system asking people to try the new one.  

- added next public url in front of callback, attempting to fix issue where users are redirected to the home page after clicking the magic link
- underline message in /booking-system with link to our new system
- Make the above link redirect with a www. to fix the issue some users had when accessing the booking system through that link
- improve wording on auth error and success pages
- make alert heights responsive to screen size so there is no scrolling needed

# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] Already rebased against main branch.

# Screenshots

Improved styling on banner in current booking system to link to new one.
![image](https://github.com/user-attachments/assets/8325a63f-e818-4fca-a542-ec2b8bbb2804)

# Issue number

Closes #403
